### PR TITLE
fix(compiler): Prevent recursive lookup during variable initialization

### DIFF
--- a/kcompiler/src/main/java/org/metavm/compiler/analyze/IdentAttr.java
+++ b/kcompiler/src/main/java/org/metavm/compiler/analyze/IdentAttr.java
@@ -49,8 +49,14 @@ public class IdentAttr extends StructuralNodeVisitor {
 
     @Override
     public Void visitDeclStmt(DeclStmt declStmt) {
-        env.currentScope().add(declStmt.getDecl().getElement());
-        return super.visitDeclStmt(declStmt);
+        if (declStmt.getDecl().getElement() instanceof Variable) {
+            super.visitDeclStmt(declStmt);
+            env.currentScope().add(declStmt.getDecl().getElement());
+            return null;
+        } else {
+            env.currentScope().add(declStmt.getDecl().getElement());
+            return super.visitDeclStmt(declStmt);
+        }
     }
 
     @Override

--- a/test/src/test/java/org/metavm/compiler/DiagTest.java
+++ b/test/src/test/java/org/metavm/compiler/DiagTest.java
@@ -285,6 +285,19 @@ public class DiagTest extends TestCase {
         log.flush();
     }
 
+    public void testSelfRefVariableInit() {
+        compile("""
+                class Lab {
+                    var a = a
+                }
+                """);
+        assertEquals(1, log.getDiags().size());
+        assertEquals("""
+                dummy.kiwi:2: Cannot resolve symbol
+                        var a = a
+                                ^""", log.getDiags().getFirst().toString());
+    }
+
     private List<Diag> compile(String text) {
         log.setSourceFile(new DummySourceFile(text));
         var parser = new Parser(


### PR DESCRIPTION
Resolves a stack overflow caused by a recursive lookup when a variable's name appeared in its own initializer.