### PR TITLE
feat(compiler): Add checks for uninitialized fields and illegal casts

### DIFF
--- a/kcompiler/src/main/java/org/metavm/compiler/analyze/Attr.java
+++ b/kcompiler/src/main/java/org/metavm/compiler/analyze/Attr.java
@@ -624,7 +624,7 @@ public class Attr extends StructuralNodeVisitor {
             if (Traces.traceAttr) {
                 logger.trace("Trying init: {}", init.getText());
             }
-            if (m.getParamTypes().matches(argumentTypes, this::isApplicable)) {
+            if (m.getParamTypes().matches(argumentTypes, Types::isApplicable)) {
                 return m;
             }
         }
@@ -632,13 +632,7 @@ public class Attr extends StructuralNodeVisitor {
     }
 
     private boolean isApplicable(List<Type> types1, List<Type> types2) {
-        return types1.matches(types2, this::isApplicable);
-    }
-
-    private boolean isApplicable(Type parameterType, Type argumentType) {
-        if (parameterType.isAssignableFrom(argumentType))
-            return true;
-        return widensTo(argumentType, parameterType);
+        return types1.matches(types2, Types::isApplicable);
     }
 
     private boolean isOverride(MethodRef override, MethodRef overridden) {
@@ -646,16 +640,6 @@ public class Attr extends StructuralNodeVisitor {
                 && overridden.getDeclType() != override.getDeclType()
                 && overridden.getDeclType().isAssignableFrom(override.getDeclType())
                 && override.getParamTypes().equals(overridden.getParamTypes());
-    }
-
-    private boolean widensTo(Type t1, Type t2) {
-        if (t1 instanceof PrimitiveType pt1) {
-            if (t2 instanceof PrimitiveType pt2)
-                return pt1.widensTo(pt2);
-            else if (t2 instanceof UnionType ut)
-                return ut.alternatives().anyMatch(alt -> widensTo(t1, alt));
-        }
-        return false;
     }
 
 }

--- a/kcompiler/src/main/java/org/metavm/compiler/diag/Errors.java
+++ b/kcompiler/src/main/java/org/metavm/compiler/diag/Errors.java
@@ -15,6 +15,7 @@ public class Errors {
     public static final Error invalidIndexValueType = create("invalid.index.value.type");
     public static final Error misplacedIndexField = create("misplaced.index.field");
     public static final Error reservedFieldName = create("reserved.field.name");
+    public static final Error fieldNotInitialized = create("field.not.initialized");
 
     public static Error ambiguousReference(String matches)  {
         return create("ambiguous.reference", matches);
@@ -100,4 +101,7 @@ public class Errors {
         return new Error(code, args);
     }
 
+    public static Error illegalCast(String from, String to) {
+        return create("illegal.cast", from, to);
+    }
 }

--- a/kcompiler/src/main/java/org/metavm/compiler/generate/Code.java
+++ b/kcompiler/src/main/java/org/metavm/compiler/generate/Code.java
@@ -251,6 +251,8 @@ public class Code {
     public void castPrim(int sourceTag, Type targetType) {
         var sourceCode = sourceTag - TypeTags.TAG_INT;
         var targetCode = targetType.getTag() - TypeTags.TAG_INT;
+        if (sourceCode == targetCode)
+            return;
         var offset = targetCode > sourceCode ? targetCode - 1 : targetCode;
         var code = INT_TO_LONG + 3 * sourceCode + offset;
         code(code);

--- a/kcompiler/src/main/java/org/metavm/compiler/syntax/Parser.java
+++ b/kcompiler/src/main/java/org/metavm/compiler/syntax/Parser.java
@@ -360,9 +360,9 @@ public class Parser {
     }
 
     private Expr asExpr() {
-        var pos = pos();
         var expr = prefixExpr();
         while (is(AS)) {
+            var pos = pos();
             nextToken();
             var type = type();
             expr = new CastExpr(type, expr).setPos(pos);

--- a/kcompiler/src/main/java/org/metavm/compiler/type/Types.java
+++ b/kcompiler/src/main/java/org/metavm/compiler/type/Types.java
@@ -85,6 +85,22 @@ public class Types {
         return ErrorType.instance;
     }
 
+    public static boolean isApplicable(Type parameterType, Type argumentType) {
+        if (parameterType.isAssignableFrom(argumentType))
+            return true;
+        return widensTo(argumentType, parameterType);
+    }
+
+    private static boolean widensTo(Type t1, Type t2) {
+        if (t1 instanceof PrimitiveType pt1) {
+            if (t2 instanceof PrimitiveType pt2)
+                return pt1.widensTo(pt2);
+            else if (t2 instanceof UnionType ut)
+                return ut.alternatives().anyMatch(alt -> widensTo(t1, alt));
+        }
+        return false;
+    }
+
     private Clazz createStringClass() {
         var clazz = new Clazz(ClassTag.CLASS, NameTable.instance.string, Access.PUBLIC, BuiltinClassScope.instance) {
 

--- a/kcompiler/src/main/resources/message/Messages.properties
+++ b/kcompiler/src/main/resources/message/Messages.properties
@@ -34,3 +34,5 @@ non.static.index.field=Index field must be static
 misplaced.index.field=Index field must be defined in the class it indexes
 invalid.index.value.type=Invalid index value type
 reserved.field.name=Reserved field name
+illegal.cast=Illegal cast from {0} to {1}
+field.not.initialized=Field not initialized

--- a/model/src/main/java/org/metavm/object/type/SaveTypeBatch.java
+++ b/model/src/main/java/org/metavm/object/type/SaveTypeBatch.java
@@ -371,19 +371,15 @@ public class SaveTypeBatch implements TypeDefProvider, ClassFileListener {
         var tracing = this.tracing;
         var fieldInfo = Objects.requireNonNull(this.fieldInfo);
         if(tracing) log.trace("Field {} updated", field.getQualifiedName());
-        if(!field.isStatic() && !field.getType().isAssignableFrom(fieldInfo.type)) {
-            addTypeChangedField(field);
-        }
-        if(fieldInfo.state != field.getState()) {
-            if(fieldInfo.state == MetadataState.REMOVED) {
-                if (field.isStatic())
-                    addNewStaticField(field);
-                else {
-                    addNewField(field);
-                    if (tracing) log.trace("Resurrecting removed field {}", field.getQualifiedName());
-                }
+        if(fieldInfo.state != field.getState() && fieldInfo.state == MetadataState.REMOVED) {
+            if (field.isStatic())
+                addNewStaticField(field);
+            else {
+                addNewField(field);
+                if (tracing) log.trace("Resurrecting removed field {}", field.getQualifiedName());
             }
-        }
+        } else if (!field.isStatic() && !field.getType().isAssignableFrom(fieldInfo.type))
+            addTypeChangedField(field);
         if (field.isEnumConstant() && (!fieldInfo.name.equals(field.getName()) || fieldInfo.ordinal != field.getOrdinal()))
             addModifiedEnumConstant(field);
         getContext().updateMemoryIndex(field);

--- a/server/src/main/java/org/metavm/object/instance/search/SearchBuilder.java
+++ b/server/src/main/java/org/metavm/object/instance/search/SearchBuilder.java
@@ -25,7 +25,7 @@ public class SearchBuilder {
 
     public static SearchSourceBuilder build(SearchQuery query) {
         SearchSourceBuilder builder = new SearchSourceBuilder();
-        builder.from(query.from()).size(query.size());
+        builder.from(query.from()).size(Math.min(query.size(), 999));
         builder.query(QueryBuilders.queryStringQuery(buildQueryString(query)));
         builder.sort(FieldNames.ID, SortOrder.DESC);
         return builder;

--- a/server/src/main/java/org/metavm/object/instance/search/SearchQuery.java
+++ b/server/src/main/java/org/metavm/object/instance/search/SearchQuery.java
@@ -24,7 +24,7 @@ public record SearchQuery(
     }
 
     public int size() {
-        return pageSize + extra;
+        return Math.min(pageSize + extra, 999);
     }
 
     public int end() {

--- a/test/src/test/java/org/metavm/compiler/DiagTest.java
+++ b/test/src/test/java/org/metavm/compiler/DiagTest.java
@@ -298,6 +298,41 @@ public class DiagTest extends TestCase {
                                 ^""", log.getDiags().getFirst().toString());
     }
 
+    public void testIllegalCast() {
+        compile("""
+                class Product(var name: string) {
+                
+                    class SKU(var variant: string, var stock: int)
+                    
+                    fn getSkus() -> SKU[] {
+                        return children as SKU[]
+                    }
+                
+                }
+                """);
+        assertEquals(1, log.getDiags().size());
+        assertEquals("""
+                dummy.kiwi:6: Illegal cast from any[] to Product.SKU[]
+                            return children as SKU[]
+                                            ^""",
+                log.getDiags().getFirst().toString());
+    }
+
+    public void testFieldNotInitialized() {
+        compile("""
+                class User(var name: string) {
+                    var passwordHash: string
+                }
+                """);
+        assertEquals(1, log.getDiags().size());
+        assertEquals("""
+                dummy.kiwi:2: Field not initialized
+                        var passwordHash: string
+                            ^""",
+                log.getDiags().getFirst().toString()
+        );
+    }
+
     private List<Diag> compile(String text) {
         log.setSourceFile(new DummySourceFile(text));
         var parser = new Parser(

--- a/test/src/test/java/org/metavm/compiler/KiwiTest2.java
+++ b/test/src/test/java/org/metavm/compiler/KiwiTest2.java
@@ -140,6 +140,15 @@ public class KiwiTest2 extends KiwiTestBase {
 
     public void testDoubleToIntCast() {
         deploy("kiwi/cast/primitive_cast.kiwi");
+
+        assertEquals(
+                1,
+                callMethod(
+                        ApiNamedObject.of("lab"),
+                        "longToInt",
+                        List.of(1)
+                ));
+
         assertEquals(
                 1.0,
                 callMethod(
@@ -163,6 +172,14 @@ public class KiwiTest2 extends KiwiTestBase {
                         "floatToLong",
                         List.of(1.0)
         ));
+
+        assertEquals(
+                1,
+                callMethod(
+                        ApiNamedObject.of("lab"),
+                        "intToInt",
+                        List.of(1)
+                ));
     }
 
     public void testCondExprSameType() {
@@ -175,6 +192,28 @@ public class KiwiTest2 extends KiwiTestBase {
                         List.of(1, 2)
                 )
         );
+    }
+
+    public void testIntLongCompare() {
+        deploy("kiwi/widening/int_long_cmp.kiwi");
+        assertEquals(
+                true,
+                callMethod(
+                        ApiNamedObject.of("lab"),
+                        "le",
+                        List.of(1, 2)
+                )
+        );
+    }
+
+    public void testSearchPageSizeLimit() {
+        deploy("kiwi/search/search.kiwi");
+        saveInstance("search.SearchFoo", Map.of(
+                "name", "Foo"
+        ));
+        TestUtils.waitForEsSync(schedulerAndWorker);
+        var r = apiClient.search("search.SearchFoo", Map.of(), 1, 10000);
+        assertEquals(1, r.total());
     }
 
 }

--- a/test/src/test/java/org/metavm/compiler/KiwiTestBase.java
+++ b/test/src/test/java/org/metavm/compiler/KiwiTestBase.java
@@ -24,7 +24,7 @@ public abstract class KiwiTestBase extends TestCase  {
     EntityContextFactory entityContextFactory;
     protected TypeManager typeManager;
     SchedulerAndWorker schedulerAndWorker;
-    private ApiClient apiClient;
+    protected ApiClient apiClient;
     protected  Id userId;
 
     @Override

--- a/test/src/test/java/org/metavm/object/instance/MemInstanceSearchServiceV2.java
+++ b/test/src/test/java/org/metavm/object/instance/MemInstanceSearchServiceV2.java
@@ -28,6 +28,8 @@ public class MemInstanceSearchServiceV2 implements InstanceSearchService {
 
     @Override
     public Page<Id> search(SearchQuery query) {
+        if(query.size() > 999)
+            throw new IllegalArgumentException("Page size cannot exceed 999");
         List<Id> result = new ArrayList<>();
         doSearch(query.appId(), query, result);
         if (query.includeBuiltin())

--- a/test/src/test/resources/kiwi/cast/primitive_cast.kiwi
+++ b/test/src/test/resources/kiwi/cast/primitive_cast.kiwi
@@ -3,6 +3,14 @@ package cast
 @Bean
 class Lab {
 
+    fn intToInt(value: int) -> int {
+        return value as int
+    }
+
+    fn longToInt(value: long) -> int {
+        return value as int
+    }
+
     fn intToDouble(value: int) -> double {
         return value as double
     }

--- a/test/src/test/resources/kiwi/enum_ddl_after.kiwi
+++ b/test/src/test/resources/kiwi/enum_ddl_after.kiwi
@@ -35,7 +35,7 @@ enum ProductKind(val code: int) {
 
 ;
 
-    priv deleted var name: string
+    priv deleted var name: string?
 
     fn getCode() -> int {
         return this.code

--- a/test/src/test/resources/kiwi/static_fields.kiwi
+++ b/test/src/test/resources/kiwi/static_fields.kiwi
@@ -1,10 +1,6 @@
 class UpdateStaticFoo {
 
-    priv static var value: int
-
-    static {
-        UpdateStaticFoo.value = 0
-    }
+    priv static var value = 0
 
     static fn set(value: int) {
         UpdateStaticFoo.value = value

--- a/test/src/test/resources/kiwi/value_to_enum_ddl_after.kiwi
+++ b/test/src/test/resources/kiwi/value_to_enum_ddl_after.kiwi
@@ -31,7 +31,7 @@ enum ProductKind(val code: int) {
 
 ;
 
-    priv deleted var name: string
+    priv deleted var name: string?
 
     fn getCode() -> int {
         return this.code

--- a/test/src/test/resources/kiwi/value_to_enum_ddl_rollback.kiwi
+++ b/test/src/test/resources/kiwi/value_to_enum_ddl_rollback.kiwi
@@ -37,5 +37,4 @@ value class ProductKind(
     priv fn __name__() -> string {
         return "Unknown"
     }
-
 }

--- a/test/src/test/resources/kiwi/widening/int_long_cmp.kiwi
+++ b/test/src/test/resources/kiwi/widening/int_long_cmp.kiwi
@@ -1,0 +1,10 @@
+package widening
+
+@Bean
+class Lab {
+
+    fn le(v1: long, v2: int) -> bool {
+        return v1 <= v2
+    }
+
+}


### PR DESCRIPTION
- A check for the use of uninitialized fields.
- A check for illegal cast expressions.

fix(compiler): Resolve issue with casting a primitive value to its original type.

chore(runtime): Limit search result size to 999