### PR TITLE
perf(vm): dual-stack interpreter to eliminate arithmetic allocation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,136 @@
+# Manul Project
+
+Manul is a programming language with its own bytecode and stack-based VM interpreter (`VmStack.java`). It compiles `.mnl` source files to custom bytecode (not JVM bytecode) and executes them on a custom VM with object pooling.
+
+## Building and Testing
+
+- **Full build**: `mvn clean package -DskipTests`
+- **Run all tests**: `mvn clean test` (from project root, NOT `-pl test` alone — the test module has broken files in `org.manul.context` and `org.manul.application` that only compile when built from root)
+- **Run a specific test**: `mvn clean test -Dtest=ManulTest#testAssign -Dsurefire.failIfNoSpecifiedTests=false`
+- **Resume from test module after root build**: Does NOT work with `-rf :manul-test` due to annotation processor issues; always build from root.
+- CI runs: `mvn -B verify --file pom.xml`
+
+## Writing Test Cases for Manul
+
+### Test infrastructure
+
+- Test base class: `org.manul.compiler.ManulTestBase` (extends JUnit 3 `TestCase`)
+- Test classes must be in `test/src/test/java/org/manul/compiler/` package to access `ManulTestBase`'s package-private methods (`deploy()`, `callMethod()`, `saveInstance()`, `getObject()`, etc.)
+- Manul source files go in `test/src/test/resources/manul/`
+
+### ManulTestBase key methods
+
+- `deploy("manul/foo.mnl")` — compiles and deploys a Manul source file
+- `deploy(List.of("manul/a.mnl", "manul/b.mnl"))` — deploy multiple files
+- `callMethod("ClassName", "methodName", List.of(arg1, arg2))` — call a static method on a class
+- `callMethod(ApiNamedObject.of("beanName"), "methodName", List.of(...))` — call a method on a bean
+- `callMethod(instanceId, "methodName", List.of(...))` — call an instance method
+- `saveInstance("ClassName", Map.of("field1", val1, ...))` — create and persist an instance, returns `Id`
+- `getObject(id)` — retrieve an `ApiObject` by Id
+- `deleteObject(id)` — delete an instance
+- `search(className, queryMap)` — search instances
+
+### Manul language syntax (`.mnl` files)
+
+```
+package mypackage
+
+// Bean (singleton service, accessed via ApiNamedObject.of("beanName") in tests)
+@Bean
+class MyService {
+    fn doSomething(x: int) -> int {
+        return x + 1
+    }
+}
+
+// Regular class (instantiated via saveInstance in tests)
+class Foo {
+    // Fields are declared implicitly by constructor/init params
+    fn getValue() -> int {
+        return this.value
+    }
+
+    // Static method
+    static fn add(a: int, b: int) -> int {
+        return a + b
+    }
+}
+
+// Inheritance
+class Sub: Base {
+    fn speak() -> string {
+        return "sub"
+    }
+}
+```
+
+#### Types
+- Primitives: `int`, `long`, `float`, `double`, `bool`, `short`, `byte`, `char`
+- Reference: `string`, `any`, custom classes
+- Nullable: `Type?` (e.g., `string?`)
+- Arrays: `Type[]` (e.g., `int[]`, `string[]`)
+- Functions: `(ParamType) -> ReturnType`
+- Generics: `class Foo<T> { ... }`, called as `Foo<string>`
+
+#### Control flow
+- `if (cond) { ... } else { ... }`
+- `for (i in collection) { ... }`
+- `for (i in 0...n) { ... }` (range)
+- `while (cond) { ... }`
+- `do { ... } while (cond)`
+- `break`, `continue`, `return`
+- Ternary: `cond ? a : b`
+- `try { ... } catch (e: ExceptionType) { ... }`
+
+#### Features
+- `@Bean` annotation for singleton beans
+- Inner classes, anonymous classes, lambdas
+- Enum classes with constants and methods
+- Value classes (value objects)
+- Method references
+- Pattern matching with `is` (instanceof)
+- Index annotations for searchable fields
+- `@label("...")` display attributes
+
+### Example test pattern
+
+```java
+// In test/src/test/java/org/manul/compiler/MyFeatureTest.java
+package org.manul.compiler;
+
+import org.junit.Assert;
+import java.util.List;
+
+public class MyFeatureTest extends ManulTestBase {
+
+    public void testMyFeature() {
+        deploy("manul/my_feature.mnl");
+        var bean = ApiNamedObject.of("myService");
+        var result = callMethod(bean, "compute", List.of(1, 2));
+        Assert.assertEquals(3, result);
+    }
+}
+```
+
+### Accessing VM internals (for low-level tests)
+
+VmStack uses a static `ObjectPool<VmStack>` pool. Use reflection to access:
+- `VmStack.class.getDeclaredField("pool")` — the `ObjectPool<VmStack>`
+- Fields on VmStack instance: `stack` (Value[]), `pStack` (long[]), `tStack` (byte[]), `frames` (Frame[])
+- Private methods: `ensureValue(int pos)`, `pushValue(int pos, Value v)`, `materializeRange(int from, int to)`
+- Type tags: T_REF=0, T_INT=1, T_LONG=2, T_DOUBLE=3, T_FLOAT=4
+
+## Key Architecture
+
+### VM (VmStack.java)
+- Dual-stack architecture: `long[] pStack` for raw primitive bits, `Value[] stack` for references, `byte[] tStack` for type tags
+- VmStack instances are pooled via `ObjectPool` with `ConcurrentLinkedQueue`
+- `ensureValue(pos)` materializes a Value from the dual stack at boundary points
+- Bytecodes defined in `Bytecodes.java` (~70 opcodes)
+
+### Module structure
+- `model/` — core VM, types, instances, flow (bytecodes, VmStack, Code, etc.)
+- `compiler/` — Manul language compiler (.mnl -> bytecode)
+- `server/` — HTTP server
+- `test/` — integration tests
+- `share/`, `api/`, `wire/`, `meta/`, `context/` — supporting modules

--- a/model/src/main/java/org/manul/flow/VmStack.java
+++ b/model/src/main/java/org/manul/flow/VmStack.java
@@ -178,16 +178,26 @@ public class VmStack {
                                 Value retRef = stack[retSlot];
 
                                 Arrays.fill(stack, base, base + code.getFrameSize(), null);
+                                Arrays.fill(tStack, base, base + code.getFrameSize(), (byte) 0);
+
+                                // Materialize from saved values (arrays are cleared)
+                                Value retValue = switch (retTag) {
+                                    case T_REF -> retRef;
+                                    case T_INT -> IntValue.of((int) retPrim);
+                                    case T_LONG -> new LongValue(retPrim);
+                                    case T_DOUBLE -> new DoubleValue(Double.longBitsToDouble(retPrim));
+                                    case T_FLOAT -> new FloatValue(Float.intBitsToFloat((int) retPrim));
+                                    default -> throw new IllegalStateException("Invalid type tag: " + retTag);
+                                };
 
                                 if (fp == 0) {
-                                    Value v = retTag != T_REF ? ensureValue(retSlot) : retRef;
-                                    return FlowExecResult.of(v);
+                                    return FlowExecResult.of(retValue);
                                 }
                                 var frame = frames[--fp];
                                 frames[fp] = null;
 
                                 // Place return value at caller's expected position
-                                stack[frame.top] = retTag != T_REF ? ensureValue(retSlot) : retRef;
+                                stack[frame.top] = retValue;
                                 pStack[frame.top] = retPrim;
                                 tStack[frame.top] = retTag;
 
@@ -1303,6 +1313,7 @@ public class VmStack {
                                     callContext.instanceRepository().updateMemoryIndex(obj);
                                 }
                                 Arrays.fill(stack, base, base + code.getFrameSize(), null);
+                                Arrays.fill(tStack, base, base + code.getFrameSize(), (byte) 0);
                                 if (fp == 0)
                                     return FlowExecResult.of(null);
                                 var frame = frames[--fp];
@@ -1470,6 +1481,7 @@ public class VmStack {
                         else {
                             var f = frames[h.fp];
                             Arrays.fill(stack, f.base + f.callableRef.getCode().getFrameSize(), base + code.getFrameSize(), null);
+                            Arrays.fill(tStack, f.base + f.callableRef.getCode().getFrameSize(), base + code.getFrameSize(), (byte) 0);
                             fp = h.fp;
                             base = f.base;
                             top = f.top;
@@ -1486,6 +1498,7 @@ public class VmStack {
                     }
                     else {
                         Arrays.fill(stack, 0, base + code.getFrameSize(), null);
+                        Arrays.fill(tStack, 0, base + code.getFrameSize(), (byte) 0);
                         return FlowExecResult.ofException(exception);
                     }
 

--- a/model/src/main/java/org/manul/flow/VmStack.java
+++ b/model/src/main/java/org/manul/flow/VmStack.java
@@ -39,11 +39,71 @@ public class VmStack {
         }
     }
 
+    // Type tags for the primitive stack
+    private static final byte T_REF = 0;
+    private static final byte T_INT = 1;
+    private static final byte T_LONG = 2;
+    private static final byte T_DOUBLE = 3;
+    private static final byte T_FLOAT = 4;
+
     private final ExceptionHandler[] exceptionHandlers = new ExceptionHandler[1024];
     private final Value[] stack = new Value[1024 * 1024];
+    private final long[] pStack = new long[1024 * 1024];
+    private final byte[] tStack = new byte[1024 * 1024];
     private final Frame[] frames = new Frame[1024];
 
     private VmStack() {
+    }
+
+    /**
+     * Materialize a Value from the dual stack at the given position.
+     * For reference slots, returns the existing Value from stack[].
+     * For primitive slots, creates a new Value from pStack[].
+     */
+    private Value ensureValue(int pos) {
+        return switch (tStack[pos]) {
+            case T_REF -> stack[pos];
+            case T_INT -> IntValue.of((int) pStack[pos]);
+            case T_LONG -> new LongValue(pStack[pos]);
+            case T_DOUBLE -> new DoubleValue(Double.longBitsToDouble(pStack[pos]));
+            case T_FLOAT -> new FloatValue(Float.intBitsToFloat((int) pStack[pos]));
+            default -> throw new IllegalStateException("Invalid type tag: " + tStack[pos]);
+        };
+    }
+
+    /**
+     * Push a Value (from an external source) onto both stacks at the given position.
+     * Extracts raw primitive bits into pStack and sets the type tag.
+     */
+    private void pushValue(int pos, Value v) {
+        stack[pos] = v;
+        if (v instanceof IntValue iv) {
+            pStack[pos] = iv.value;
+            tStack[pos] = T_INT;
+        } else if (v instanceof LongValue lv) {
+            pStack[pos] = lv.value;
+            tStack[pos] = T_LONG;
+        } else if (v instanceof DoubleValue dv) {
+            pStack[pos] = Double.doubleToRawLongBits(dv.value);
+            tStack[pos] = T_DOUBLE;
+        } else if (v instanceof FloatValue fv) {
+            pStack[pos] = Float.floatToRawIntBits(fv.value);
+            tStack[pos] = T_FLOAT;
+        } else {
+            tStack[pos] = T_REF;
+        }
+    }
+
+    /**
+     * Ensure all primitive slots in [from, to) have a materialized Value in stack[].
+     * Used before capturing stack slices into ClosureContext.
+     */
+    private void materializeRange(int from, int to) {
+        for (int i = from; i < to; i++) {
+            if (tStack[i] != T_REF) {
+                stack[i] = ensureValue(i);
+            }
+        }
     }
 
     @SuppressWarnings({"DuplicatedCode", "UseCompareMethod", "DataFlowIssue", "ExtractMethodRecommender"})
@@ -52,17 +112,15 @@ public class VmStack {
                                            @Nullable ClosureContext closureContext,
                                            CallContext callContext) {
 
-//        if(DebugEnv.flag) {
-//            log.debug("Executing flow {}, maxLocals: {}, maxStack: {}, constants: {}, code length: {}",
-//                    scope.getCallable(), scope.getMaxLocals(), scope.getMaxStack(), scope.getConstantPool().getEntries().size(),
-//                    scope.getCode().length);
-//            log.debug("{}", EncodingUtils.bytesToHex(scope.getCode()));
-//            log.debug("Constants: {}", Arrays.toString(scope.getConstantPool().getResolvedValues()));
-//        }
         try {
             var constants = callableRef.getTypeMetadata().getValues();
-            System.arraycopy(arguments, 0, stack, 0, arguments.length);
+            // Initialize arguments into both stacks
+            for (int i = 0; i < arguments.length; i++) {
+                pushValue(i, arguments[i]);
+            }
             var stack = this.stack;
+            var pStack = this.pStack;
+            var tStack = this.tStack;
             var frames = this.frames;
             int base = 0;
             var code = callableRef.getCode();
@@ -77,8 +135,6 @@ public class VmStack {
             for (;;) {
                 var b = bytes[pc] & 0xff;
                 try {
-//                    if(DebugEnv.flag)
-//                        log.debug("Executing bytecode {} at {}, top: {}, callable: {}", Bytecodes.getBytecodeName(b), pc, top, callableRef);
                     except: {
                         switch (b) {
                             case Bytecodes.ADD_OBJECT -> {
@@ -88,34 +144,53 @@ public class VmStack {
                                 var instance = ClassInstanceBuilder.newBuilder(type, repository.allocateRootId(type))
                                         .ephemeral(ephemeral)
                                         .build();
-                                var fieldValues = new LinkedList<Value>();
                                 var fields = type.getKlass().getAllFields();
                                 int numFields = fields.size();
-                                for (int i = 0; i < numFields; i++) {
-                                    fieldValues.addFirst(stack[--top]);
+                                var fieldValues = new Value[numFields];
+                                for (int i = numFields - 1; i >= 0; i--) {
+                                    fieldValues[i] = ensureValue(--top);
                                 }
-                                Utils.biForEach(fields, fieldValues, (f, v) -> instance.initField(f, f.getType().fromStackValue(v)));
+                                var fieldIt = fields.iterator();
+                                for (int i = 0; i < numFields; i++) {
+                                    var f = fieldIt.next();
+                                    instance.initField(f, f.getType().fromStackValue(fieldValues[i]));
+                                }
                                 if (!instance.isEphemeral())
                                     callContext.instanceRepository().bind(instance);
-                                stack[top++] = instance.getReference();
+                                stack[top] = instance.getReference();
+                                tStack[top] = T_REF;
+                                top++;
                                 pc += 4;
                             }
                             case Bytecodes.SET_FIELD -> {
                                 int fieldIndex = (bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff;
                                 var field = (FieldRef) constants[fieldIndex];
-                                var value = stack[--top];
+                                var value = ensureValue(--top);
                                 var instance = stack[--top].resolveMvObject();
                                 instance.fields[field.getRawField().offset].value = field.getPropertyType().fromStackValue(value);
                                 pc += 3;
                             }
                             case Bytecodes.RETURN -> {
-                                var v = stack[top - 1];
+                                // Save return value before cleanup
+                                int retSlot = top - 1;
+                                long retPrim = pStack[retSlot];
+                                byte retTag = tStack[retSlot];
+                                Value retRef = stack[retSlot];
+
                                 Arrays.fill(stack, base, base + code.getFrameSize(), null);
-                                if (fp == 0)
+
+                                if (fp == 0) {
+                                    Value v = retTag != T_REF ? ensureValue(retSlot) : retRef;
                                     return FlowExecResult.of(v);
+                                }
                                 var frame = frames[--fp];
                                 frames[fp] = null;
-                                stack[frame.top] = v;
+
+                                // Place return value at caller's expected position
+                                stack[frame.top] = retTag != T_REF ? ensureValue(retSlot) : retRef;
+                                pStack[frame.top] = retPrim;
+                                tStack[frame.top] = retTag;
+
                                 pc = frame.pc;
                                 top = frame.top + 1;
                                 base = frame.base;
@@ -140,15 +215,17 @@ public class VmStack {
                                     var paramCount = method.getParameterCount();
                                     var args = new Value[paramCount];
                                     for (int i = paramCount - 1; i >= 0; i--) {
-                                        args[i] = stack[--top];
+                                        args[i] = ensureValue(--top);
                                     }
                                     top--;
                                     var r = NativeMethods.invoke(method.getRawFlow(), self, List.of(args), callContext);
                                     if (r.exception() != null) {
                                         exception = r.exception();
                                         break except;
-                                    } else if (!method.getReturnType().isVoid())
-                                        stack[top++] = r.ret();
+                                    } else if (!method.getReturnType().isVoid()) {
+                                        pushValue(top, r.ret());
+                                        top++;
+                                    }
                                 } else {
                                     int prevBase = base;
                                     base = top - method.getParameterCount() - 1;
@@ -180,15 +257,17 @@ public class VmStack {
                                     var paramCount = method.getParameterCount();
                                     var args = new Value[paramCount];
                                     for (int i = paramCount - 1; i >= 0; i--) {
-                                        args[i] = stack[--top];
+                                        args[i] = ensureValue(--top);
                                     }
                                     top--;
                                     var r = NativeMethods.invoke(method.getRawFlow(), self, List.of(args), callContext);
                                     if (r.exception() != null) {
                                         exception = r.exception();
                                         break except;
-                                    } else if (!method.getReturnType().isVoid())
-                                        stack[top++] = r.ret();
+                                    } else if (!method.getReturnType().isVoid()) {
+                                        pushValue(top, r.ret());
+                                        top++;
+                                    }
                                 } else {
                                     int prevBase = base;
                                     base = top - method.getParameterCount() - 1;
@@ -211,15 +290,17 @@ public class VmStack {
                                     var paramCount = method.getParameterCount();
                                     var args = new Value[paramCount];
                                     for (int i = paramCount - 1; i >= 0; i--) {
-                                        args[i] = stack[--top];
+                                        args[i] = ensureValue(--top);
                                     }
                                     top--;
                                     var r = NativeMethods.invoke(method.getRawFlow(), self, List.of(args), callContext);
                                     if (r.exception() != null) {
                                         exception = r.exception();
                                         break except;
-                                    } else if (!method.getReturnType().isVoid())
-                                        stack[top++] = r.ret();
+                                    } else if (!method.getReturnType().isVoid()) {
+                                        pushValue(top, r.ret());
+                                        top++;
+                                    }
                                 } else {
                                     int prevBase = base;
                                     base = top - method.getParameterCount() - 1;
@@ -249,15 +330,17 @@ public class VmStack {
                                     var paramCount = method.getParameterCount();
                                     var args = new Value[paramCount];
                                     for (int i = paramCount - 1; i >= 0; i--) {
-                                        args[i] = stack[--top];
+                                        args[i] = ensureValue(--top);
                                     }
                                     top--;
                                     var r = NativeMethods.invoke(method.getRawFlow(), self, List.of(args), callContext);
                                     if (r.exception() != null) {
                                         exception = r.exception();
                                         break except;
-                                    } else if (!method.getReturnType().isVoid())
-                                        stack[top++] = r.ret();
+                                    } else if (!method.getReturnType().isVoid()) {
+                                        pushValue(top, r.ret());
+                                        top++;
+                                    }
                                 } else {
                                     int prevBase = base;
                                     base = top - method.getParameterCount() - 1;
@@ -279,14 +362,16 @@ public class VmStack {
                                     var paramCount = method.getParameterCount();
                                     var args = new Value[paramCount];
                                     for (int i = paramCount - 1; i >= 0; i--) {
-                                        args[i] = stack[--top];
+                                        args[i] = ensureValue(--top);
                                     }
                                     var r = NativeMethods.invoke(method.getRawFlow(), null, List.of(args), callContext);
                                     if (r.exception() != null) {
                                         exception = r.exception();
                                         break except;
-                                    } else if (!method.getReturnType().isVoid())
-                                        stack[top++] = r.ret();
+                                    } else if (!method.getReturnType().isVoid()) {
+                                        pushValue(top, r.ret());
+                                        top++;
+                                    }
                                 } else {
                                     int prevBase = base;
                                     base = top - method.getParameterCount();
@@ -315,14 +400,16 @@ public class VmStack {
                                     var paramCount = method.getParameterCount();
                                     var args = new Value[paramCount];
                                     for (int i = paramCount - 1; i >= 0; i--) {
-                                        args[i] = stack[--top];
+                                        args[i] = ensureValue(--top);
                                     }
                                     var r = NativeMethods.invoke(method.getRawFlow(), null, List.of(args), callContext);
                                     if (r.exception() != null) {
                                         exception = r.exception();
                                         break except;
-                                    } else if (!method.getReturnType().isVoid())
-                                        stack[top++] = r.ret();
+                                    } else if (!method.getReturnType().isVoid()) {
+                                        pushValue(top, r.ret());
+                                        top++;
+                                    }
                                 } else {
                                     int prevBase = base;
                                     base = top - method.getParameterCount();
@@ -338,10 +425,11 @@ public class VmStack {
                             }
                             case Bytecodes.GET_UNIQUE -> {
                                 var index = ((IndexRef) constants[(bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff]);
-                                Value result = callContext.instanceRepository().selectFirstByKey(loadIndexKey(index, stack[--top]));
+                                Value result = callContext.instanceRepository().selectFirstByKey(loadIndexKey(index, ensureValue(--top)));
                                 if (result == null)
-                                    result = new NullValue();
-                                stack[top++] = result;
+                                    result = NullValue.instance;
+                                pushValue(top, result);
+                                top++;
                                 pc += 3;
                             }
                             case Bytecodes.NEW -> {
@@ -349,36 +437,43 @@ public class VmStack {
                                 var type = (ClassType) constants[typeIndex];
                                 var ephemeral = bytes[pc + 3] == 1;
                                 var unbound = bytes[pc + 4] == 1;
+                                if (type.isLocal()) materializeRange(base, top);
                                 var self = ClassInstanceBuilder.newBuilder(type, repository.allocateRootId(type))
                                         .ephemeral(ephemeral)
                                         .closureContext(type.isLocal() ? new ClosureContext(closureContext, Arrays.copyOfRange(stack, base, top)) : null)
                                         .build();
                                 if (!self.isEphemeral() && !unbound)
                                     callContext.instanceRepository().bind(self);
-                                stack[top++] = self.getReference();
+                                stack[top] = self.getReference();
+                                tStack[top] = T_REF;
+                                top++;
                                 pc += 5;
                             }
                             case Bytecodes.NEW_CHILD -> {
                                 var typeIndex = (bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff;
                                 var type = (ClassType) constants[typeIndex];
                                 var parent = stack[--top].resolveObject();
+                                if (type.isLocal()) materializeRange(base, top);
                                 var self = ClassInstanceBuilder.newBuilder(type, parent.getRoot().nextChildId())
                                         .parent(parent)
                                         .closureContext(type.isLocal() ? new ClosureContext(closureContext, Arrays.copyOfRange(stack, base, top + 1)) : null)
                                         .build();
-                                stack[top++] = self.getReference();
+                                stack[top] = self.getReference();
+                                tStack[top] = T_REF;
+                                top++;
                                 pc += 3;
                             }
                             case Bytecodes.SET_STATIC -> {
                                 var field = (FieldRef) constants[(bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff];
                                 var sft = StaticFieldTable.getInstance(field.getDeclaringType(), ContextUtil.getEntityContext());
-                                sft.set(field.getRawField(), stack[--top]);
+                                sft.set(field.getRawField(), ensureValue(--top));
                                 pc += 3;
                             }
                             case Bytecodes.NEW_ARRAY -> {
-                                // TODO support ephemeral
                                 var array = new ArrayInstance((ArrayType) constants[(bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff]);
-                                stack[top++] = array.getReference();
+                                stack[top] = array.getReference();
+                                tStack[top] = T_REF;
+                                top++;
                                 pc += 3;
                             }
                             case Bytecodes.TRY_ENTER -> {
@@ -412,38 +507,46 @@ public class VmStack {
                             }
                             case Bytecodes.LAMBDA -> {
                                 var lambda = (LambdaRef) constants[(bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff];
+                                materializeRange(base, top);
                                 var func = new LambdaValue(lambda, new ClosureContext(closureContext, Arrays.copyOfRange(stack, base, top)));
                                 if (bytes[pc + 3] == 0) {
-                                    stack[top++] = func;
+                                    stack[top] = func;
+                                    tStack[top] = T_REF;
+                                    top++;
                                     pc += 4;
                                 } else {
                                     var functionalInterface = (ClassType) constants[bytes[pc + 4] | bytes[pc + 5]];
-                                    // TODO Pre-generate functional interface implementation
                                     var functionInterfaceImpl = Types.createFunctionalClass(functionalInterface);
                                     var funcImplKlass = functionInterfaceImpl.getKlass();
                                     var funcField = funcImplKlass.getFieldByName("func");
-                                    stack[top++] = ClassInstance.create(TmpId.random(), Map.of(funcField, func), functionInterfaceImpl).getReference();
+                                    stack[top] = ClassInstance.create(TmpId.random(), Map.of(funcField, func), functionInterfaceImpl).getReference();
+                                    tStack[top] = T_REF;
+                                    top++;
                                     pc += 6;
                                 }
                             }
                             case Bytecodes.ADD_ELEMENT -> {
-                                var e = stack[--top];
+                                var e = ensureValue(--top);
                                 var a = stack[--top].resolveArray();
                                 a.addElement(a.getInstanceType().getElementType().fromStackValue(e));
                                 pc++;
                             }
                             case Bytecodes.DELETE_ELEMENT -> {
-                                var elem = stack[--top];
+                                var elem = ensureValue(--top);
                                 var array = stack[--top].resolveArray();
                                 var r = array.remove(elem);
-                                stack[top++] = Instances.intInstance(r);
+                                pStack[top] = r ? 1 : 0;
+                                tStack[top] = T_INT;
+                                top++;
                                 pc++;
                             }
                             case Bytecodes.GET_ELEMENT -> {
-                                var index = ((IntValue) stack[--top]).value;
+                                var index = (int) pStack[--top];
                                 var arrayInst = stack[--top].resolveArray();
                                 if (index < arrayInst.size()) {
-                                    stack[top++] = arrayInst.get(index).toStackValue();
+                                    var elem = arrayInst.get(index).toStackValue();
+                                    pushValue(top, elem);
+                                    top++;
                                     pc++;
                                 } else {
                                     exception = ClassInstance.allocate(TmpId.random(), StdKlass.exception.type());
@@ -459,15 +562,17 @@ public class VmStack {
                                     var paramCount = func.getParameterCount();
                                     var args = new Value[paramCount];
                                     for (int i = paramCount - 1; i >= 0; i--) {
-                                        args[i] = stack[--top];
+                                        args[i] = ensureValue(--top);
                                     }
                                     var nativeCode = Objects.requireNonNull(func.getRawFlow().getNativeCode());
                                     var r = nativeCode.run(func, List.of(args), callContext);
                                     if (r.exception() != null) {
                                         exception = r.exception();
                                         break except;
-                                    } else if (!func.getReturnType().isVoid())
-                                        stack[top++] = r.ret();
+                                    } else if (!func.getReturnType().isVoid()) {
+                                        pushValue(top, r.ret());
+                                        top++;
+                                    }
                                 } else {
                                     int prevBase = base;
                                     base = top - func.getParameterCount();
@@ -495,15 +600,17 @@ public class VmStack {
                                     var paramCount = func.getParameterCount();
                                     var args = new Value[paramCount];
                                     for (int i = paramCount - 1; i >= 0; i--) {
-                                        args[i] = stack[--top];
+                                        args[i] = ensureValue(--top);
                                     }
                                     var nativeCode = Objects.requireNonNull(func.getRawFlow().getNativeCode());
                                     var r = nativeCode.run(func, List.of(args), callContext);
                                     if (r.exception() != null) {
                                         exception = r.exception();
                                         break except;
-                                    } else if (!func.getReturnType().isVoid())
-                                        stack[top++] = r.ret();
+                                    } else if (!func.getReturnType().isVoid()) {
+                                        pushValue(top, r.ret());
+                                        top++;
+                                    }
                                 } else {
                                     int prevBase = base;
                                     base = top - func.getParameterCount();
@@ -518,13 +625,15 @@ public class VmStack {
                                 }
                             }
                             case Bytecodes.CAST -> {
-                                var inst = stack[--top];
+                                var inst = ensureValue(--top);
                                 var type = (Type) constants[(bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff];
                                 if (type.isInstance(inst)) {
-                                    stack[top++] = inst;
+                                    pushValue(top, inst);
+                                    top++;
                                     pc += 3;
                                 } else if (type.isAssignableFrom(inst.getValueType())) {
-                                    stack[top++] = inst;
+                                    pushValue(top, inst);
+                                    top++;
                                     pc += 3;
                                 } else {
                                     exception = ClassInstance.allocate(TmpId.random(), StdKlass.exception.get().getType());
@@ -542,44 +651,54 @@ public class VmStack {
                             case Bytecodes.COPY -> {
                                 var sourceInst = stack[--top];
                                 var copy = sourceInst.resolveMv().copy(repository::allocateRootId);
-                                stack[top++] = copy.getReference();
+                                stack[top] = copy.getReference();
+                                tStack[top] = T_REF;
+                                top++;
                                 pc++;
                             }
                             case Bytecodes.INDEX_SCAN -> {
                                 //noinspection DuplicatedCode
                                 var index = (IndexRef) constants[(bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff];
-                                var to = loadIndexKey(index, stack[--top]);
-                                var from = loadIndexKey(index, stack[--top]);
+                                var to = loadIndexKey(index, ensureValue(--top));
+                                var from = loadIndexKey(index, ensureValue(--top));
                                 var result = callContext.instanceRepository().indexScan(from, to);
                                 var type = new ArrayType(index.getDeclaringType(), ArrayKind.READ_ONLY);
-                                stack[top++] = new ArrayInstance(type, result).getReference();
+                                stack[top] = new ArrayInstance(type, result).getReference();
+                                tStack[top] = T_REF;
+                                top++;
                                 pc += 3;
                             }
                             case Bytecodes.INDEX_COUNT -> {
                                 //noinspection DuplicatedCode
                                 var index = (IndexRef) constants[(bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff];
-                                var to = loadIndexKey(index, stack[--top]);
-                                var from = loadIndexKey(index, stack[--top]);
+                                var to = loadIndexKey(index, ensureValue(--top));
+                                var from = loadIndexKey(index, ensureValue(--top));
                                 var count = callContext.instanceRepository().indexCount(from, to);
-                                stack[top++] = new LongValue(count);
+                                pStack[top] = count;
+                                tStack[top] = T_LONG;
+                                top++;
                                 pc += 3;
                             }
                             case Bytecodes.INDEX_SELECT -> {
                                 var index = (IndexRef) constants[(bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff];
-                                var result = callContext.instanceRepository().indexSelect(loadIndexKey(index, stack[--top]));
+                                var result = callContext.instanceRepository().indexSelect(loadIndexKey(index, ensureValue(--top)));
                                 var type = Types.getArrayType(index.getDeclaringType());
                                 var list = Instances.createArray(type, result);
-                                stack[top++] = list.getReference();
+                                stack[top] = list.getReference();
+                                tStack[top] = T_REF;
+                                top++;
                                 pc += 3;
                             }
                             case Bytecodes.INDEX_SELECT_FIRST -> {
                                 var index = (IndexRef) constants[(bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff];
-                                var result = callContext.instanceRepository().selectFirstByKey(loadIndexKey(index, stack[--top]));
-                                stack[top++] = Utils.orElse(result, new NullValue());
+                                var result = callContext.instanceRepository().selectFirstByKey(loadIndexKey(index, ensureValue(--top)));
+                                var v = Utils.orElse(result, NullValue.instance);
+                                pushValue(top, v);
+                                top++;
                                 pc += 3;
                             }
                             case Bytecodes.NON_NULL -> {
-                                var inst = stack[top - 1];
+                                var inst = ensureValue(top - 1);
                                 if (inst.isNull()) {
                                     exception = ClassInstance.allocate(TmpId.random(), StdKlass.exception.type());
                                     ExceptionNative.Exception(exception, Instances.stringInstance("Null pointer"));
@@ -588,467 +707,579 @@ public class VmStack {
                                     pc++;
                             }
                             case Bytecodes.SET_ELEMENT -> {
-                                var e = stack[--top];
-                                var i = ((IntValue) stack[--top]).value;
+                                var e = ensureValue(--top);
+                                var i = (int) pStack[--top];
                                 var a = stack[--top].resolveArray();
                                 a.setElement(i, a.getInstanceType().getElementType().fromStackValue(e));
                                 pc++;
                             }
+
+                            // --- Control flow: read from pStack ---
                             case Bytecodes.IF_EQ -> {
-                                if (((IntValue) stack[--top]).value == 0)
+                                if ((int) pStack[--top] == 0)
                                     pc += (short) ((bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff);
                                 else
                                     pc += 3;
                             }
                             case Bytecodes.IF_NE -> {
-                                if (((IntValue) stack[--top]).value != 0)
+                                if ((int) pStack[--top] != 0)
                                     pc += (short) ((bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff);
                                 else
                                     pc += 3;
                             }
                             case Bytecodes.GOTO -> pc += (short) ((bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff);
+
+                            // --- Integer arithmetic: zero allocation, pStack only ---
                             case Bytecodes.INT_ADD -> {
-                                var v2 = (IntValue) stack[--top];
-                                var v1 = (IntValue) stack[--top];
-                                stack[top++] = new IntValue(v1.value + v2.value);
+                                int v2 = (int) pStack[--top];
+                                int v1 = (int) pStack[--top];
+                                pStack[top] = v1 + v2;
+                                tStack[top] = T_INT;
+                                top++;
                                 pc++;
                             }
                             case Bytecodes.INT_SUB -> {
-                                var v2 = (IntValue) stack[--top];
-                                var v1 = (IntValue) stack[--top];
-                                stack[top++] = new IntValue(v1.value - v2.value);
+                                int v2 = (int) pStack[--top];
+                                int v1 = (int) pStack[--top];
+                                pStack[top] = v1 - v2;
+                                tStack[top] = T_INT;
+                                top++;
                                 pc++;
                             }
                             case Bytecodes.INT_MUL -> {
-                                var v2 = (IntValue) stack[--top];
-                                var v1 = (IntValue) stack[--top];
-                                stack[top++] = new IntValue(v1.value * v2.value);
+                                int v2 = (int) pStack[--top];
+                                int v1 = (int) pStack[--top];
+                                pStack[top] = v1 * v2;
+                                tStack[top] = T_INT;
+                                top++;
                                 pc++;
                             }
                             case Bytecodes.INT_DIV -> {
-                                var v2 = ((IntValue) stack[--top]).value;
-                                var v1 = ((IntValue) stack[--top]).value;
+                                int v2 = (int) pStack[--top];
+                                int v1 = (int) pStack[--top];
                                 if (v2 == 0) {
                                     exception = ClassInstance.allocate(TmpId.random(), StdKlass.exception.type());
                                     ExceptionNative.Exception(exception, Instances.stringInstance("/ by zero"));
                                     break except;
                                 } else {
-                                    stack[top++] = new IntValue(v1 / v2);
+                                    pStack[top] = v1 / v2;
+                                    tStack[top] = T_INT;
+                                    top++;
                                     pc++;
                                 }
                             }
                             case Bytecodes.INT_REM -> {
-                                var v2 = ((IntValue) stack[--top]).value;
-                                var v1 = ((IntValue) stack[--top]).value;
+                                int v2 = (int) pStack[--top];
+                                int v1 = (int) pStack[--top];
                                 if (v2 == 0) {
                                     exception = ClassInstance.allocate(TmpId.random(), StdKlass.exception.type());
                                     ExceptionNative.Exception(exception, Instances.stringInstance("/ by zero"));
                                     break except;
                                 } else {
-                                    stack[top++] = new IntValue(v1 % v2);
+                                    pStack[top] = v1 % v2;
+                                    tStack[top] = T_INT;
+                                    top++;
                                     pc++;
                                 }
                             }
+
+                            // --- Long arithmetic: zero allocation, pStack only ---
                             case Bytecodes.LONG_ADD -> {
-                                var v2 = (LongValue) stack[--top];
-                                var v1 = (LongValue) stack[--top];
-                                stack[top++] = new LongValue(v1.value + v2.value);
+                                long v2 = pStack[--top];
+                                long v1 = pStack[--top];
+                                pStack[top] = v1 + v2;
+                                tStack[top] = T_LONG;
+                                top++;
                                 pc++;
                             }
                             case Bytecodes.LONG_SUB -> {
-                                var v2 = (LongValue) stack[--top];
-                                var v1 = (LongValue) stack[--top];
-                                stack[top++] = new LongValue(v1.value - v2.value);
+                                long v2 = pStack[--top];
+                                long v1 = pStack[--top];
+                                pStack[top] = v1 - v2;
+                                tStack[top] = T_LONG;
+                                top++;
                                 pc++;
                             }
                             case Bytecodes.LONG_MUL -> {
-                                var v2 = (LongValue) stack[--top];
-                                var v1 = (LongValue) stack[--top];
-                                stack[top++] = new LongValue(v1.value * v2.value);
+                                long v2 = pStack[--top];
+                                long v1 = pStack[--top];
+                                pStack[top] = v1 * v2;
+                                tStack[top] = T_LONG;
+                                top++;
                                 pc++;
                             }
                             case Bytecodes.LONG_DIV -> {
-                                var v2 = ((LongValue) stack[--top]).value;
-                                var v1 = ((LongValue) stack[--top]).value;
+                                long v2 = pStack[--top];
+                                long v1 = pStack[--top];
                                 if (v2 == 0) {
                                     exception = ClassInstance.allocate(TmpId.random(), StdKlass.exception.type());
                                     ExceptionNative.Exception(exception, Instances.stringInstance("/ by zero"));
                                     break except;
                                 } else {
-                                    stack[top++] = new LongValue(v1 / v2);
+                                    pStack[top] = v1 / v2;
+                                    tStack[top] = T_LONG;
+                                    top++;
                                     pc++;
                                 }
                             }
                             case Bytecodes.LONG_REM -> {
-                                var v2 = ((LongValue) stack[--top]).value;
-                                var v1 = ((LongValue) stack[--top]).value;
+                                long v2 = pStack[--top];
+                                long v1 = pStack[--top];
                                 if (v2 == 0) {
                                     exception = ClassInstance.allocate(TmpId.random(), StdKlass.exception.type());
                                     ExceptionNative.Exception(exception, Instances.stringInstance("/ by zero"));
                                     break except;
                                 } else {
-                                    stack[top++] = new LongValue(v1 % v2);
+                                    pStack[top] = v1 % v2;
+                                    tStack[top] = T_LONG;
+                                    top++;
                                     pc++;
                                 }
                             }
+
+                            // --- Double arithmetic: zero allocation, pStack only ---
                             case Bytecodes.DOUBLE_ADD -> {
-                                var v2 = (DoubleValue) stack[--top];
-                                var v0 = stack[--top];
-                                var v1 = (DoubleValue) v0;
-                                stack[top++] = new DoubleValue(v1.value + v2.value);
+                                double v2 = Double.longBitsToDouble(pStack[--top]);
+                                double v1 = Double.longBitsToDouble(pStack[--top]);
+                                pStack[top] = Double.doubleToRawLongBits(v1 + v2);
+                                tStack[top] = T_DOUBLE;
+                                top++;
                                 pc++;
                             }
                             case Bytecodes.DOUBLE_SUB -> {
-                                var v2 = (DoubleValue) stack[--top];
-                                var v1 = (DoubleValue) stack[--top];
-                                stack[top++] = new DoubleValue(v1.value - v2.value);
+                                double v2 = Double.longBitsToDouble(pStack[--top]);
+                                double v1 = Double.longBitsToDouble(pStack[--top]);
+                                pStack[top] = Double.doubleToRawLongBits(v1 - v2);
+                                tStack[top] = T_DOUBLE;
+                                top++;
                                 pc++;
                             }
                             case Bytecodes.DOUBLE_MUL -> {
-                                var v2 = (DoubleValue) stack[--top];
-                                var v1 = (DoubleValue) stack[--top];
-                                stack[top++] = new DoubleValue(v1.value * v2.value);
+                                double v2 = Double.longBitsToDouble(pStack[--top]);
+                                double v1 = Double.longBitsToDouble(pStack[--top]);
+                                pStack[top] = Double.doubleToRawLongBits(v1 * v2);
+                                tStack[top] = T_DOUBLE;
+                                top++;
                                 pc++;
                             }
                             case Bytecodes.DOUBLE_DIV -> {
-                                var v2 = (DoubleValue) stack[--top];
-                                var v1 = (DoubleValue) stack[--top];
-                                stack[top++] = new DoubleValue(v1.value / v2.value);
+                                double v2 = Double.longBitsToDouble(pStack[--top]);
+                                double v1 = Double.longBitsToDouble(pStack[--top]);
+                                pStack[top] = Double.doubleToRawLongBits(v1 / v2);
+                                tStack[top] = T_DOUBLE;
+                                top++;
                                 pc++;
                             }
                             case Bytecodes.DOUBLE_REM -> {
-                                var v2 = (DoubleValue) stack[--top];
-                                var v1 = (DoubleValue) stack[--top];
-                                stack[top++] = new DoubleValue(v1.value % v2.value);
+                                double v2 = Double.longBitsToDouble(pStack[--top]);
+                                double v1 = Double.longBitsToDouble(pStack[--top]);
+                                pStack[top] = Double.doubleToRawLongBits(v1 % v2);
+                                tStack[top] = T_DOUBLE;
+                                top++;
                                 pc++;
                             }
+
+                            // --- Float arithmetic: zero allocation, pStack only ---
                             case Bytecodes.FLOAT_ADD -> {
-                                var v2 = (FloatValue) stack[--top];
-                                var v1 = (FloatValue) stack[--top];
-                                stack[top++] = new FloatValue(v1.value + v2.value);
+                                float v2 = Float.intBitsToFloat((int) pStack[--top]);
+                                float v1 = Float.intBitsToFloat((int) pStack[--top]);
+                                pStack[top] = Float.floatToRawIntBits(v1 + v2);
+                                tStack[top] = T_FLOAT;
+                                top++;
                                 pc++;
                             }
                             case Bytecodes.FLOAT_SUB -> {
-                                var v2 = (FloatValue) stack[--top];
-                                var v1 = (FloatValue) stack[--top];
-                                stack[top++] = new FloatValue(v1.value - v2.value);
+                                float v2 = Float.intBitsToFloat((int) pStack[--top]);
+                                float v1 = Float.intBitsToFloat((int) pStack[--top]);
+                                pStack[top] = Float.floatToRawIntBits(v1 - v2);
+                                tStack[top] = T_FLOAT;
+                                top++;
                                 pc++;
                             }
                             case Bytecodes.FLOAT_MUL -> {
-                                var v2 = (FloatValue) stack[--top];
-                                var v1 = (FloatValue) stack[--top];
-                                stack[top++] = new FloatValue(v1.value * v2.value);
+                                float v2 = Float.intBitsToFloat((int) pStack[--top]);
+                                float v1 = Float.intBitsToFloat((int) pStack[--top]);
+                                pStack[top] = Float.floatToRawIntBits(v1 * v2);
+                                tStack[top] = T_FLOAT;
+                                top++;
                                 pc++;
                             }
                             case Bytecodes.FLOAT_DIV -> {
-                                var v2 = (FloatValue) stack[--top];
-                                var v1 = (FloatValue) stack[--top];
-                                stack[top++] = new FloatValue(v1.value / v2.value);
+                                float v2 = Float.intBitsToFloat((int) pStack[--top]);
+                                float v1 = Float.intBitsToFloat((int) pStack[--top]);
+                                pStack[top] = Float.floatToRawIntBits(v1 / v2);
+                                tStack[top] = T_FLOAT;
+                                top++;
                                 pc++;
                             }
                             case Bytecodes.FLOAT_REM -> {
-                                var v2 = (FloatValue) stack[--top];
-                                var v1 = (FloatValue) stack[--top];
-                                stack[top++] = new FloatValue(v1.value % v2.value);
+                                float v2 = Float.intBitsToFloat((int) pStack[--top]);
+                                float v1 = Float.intBitsToFloat((int) pStack[--top]);
+                                pStack[top] = Float.floatToRawIntBits(v1 % v2);
+                                tStack[top] = T_FLOAT;
+                                top++;
                                 pc++;
                             }
+
+                            // --- Shift and bitwise: zero allocation, pStack only ---
                             case Bytecodes.INT_SHIFT_LEFT -> {
-                                var v2 = (IntValue) stack[--top];
-                                var v1 = (IntValue) stack[--top];
-                                stack[top++] = new IntValue(v1.value << v2.value);
+                                int v2 = (int) pStack[--top];
+                                int v1 = (int) pStack[--top];
+                                pStack[top] = v1 << v2;
+                                tStack[top] = T_INT;
+                                top++;
                                 pc++;
                             }
                             case Bytecodes.INT_SHIFT_RIGHT -> {
-                                var v2 = (IntValue) stack[--top];
-                                var v1 = (IntValue) stack[--top];
-                                stack[top++] = new IntValue(v1.value >> v2.value);
+                                int v2 = (int) pStack[--top];
+                                int v1 = (int) pStack[--top];
+                                pStack[top] = v1 >> v2;
+                                tStack[top] = T_INT;
+                                top++;
                                 pc++;
                             }
                             case Bytecodes.INT_UNSIGNED_SHIFT_RIGHT -> {
-                                var v2 = (IntValue) stack[--top];
-                                var v1 = (IntValue) stack[--top];
-                                stack[top++] = new IntValue(v1.value >>> v2.value);
+                                int v2 = (int) pStack[--top];
+                                int v1 = (int) pStack[--top];
+                                pStack[top] = v1 >>> v2;
+                                tStack[top] = T_INT;
+                                top++;
                                 pc++;
                             }
                             case Bytecodes.LONG_SHIFT_LEFT -> {
-                                var v2 = (IntValue) stack[--top];
-                                var v1 = (LongValue) stack[--top];
-                                stack[top++] = new LongValue(v1.value << v2.value);
+                                int v2 = (int) pStack[--top];
+                                long v1 = pStack[--top];
+                                pStack[top] = v1 << v2;
+                                tStack[top] = T_LONG;
+                                top++;
                                 pc++;
                             }
                             case Bytecodes.LONG_SHIFT_RIGHT -> {
-                                var v2 = (IntValue) stack[--top];
-                                var v1 = (LongValue) stack[--top];
-                                stack[top++] = new LongValue(v1.value >> v2.value);
+                                int v2 = (int) pStack[--top];
+                                long v1 = pStack[--top];
+                                pStack[top] = v1 >> v2;
+                                tStack[top] = T_LONG;
+                                top++;
                                 pc++;
                             }
                             case Bytecodes.LONG_UNSIGNED_SHIFT_RIGHT -> {
-                                var v2 = (IntValue) stack[--top];
-                                var v1 = (LongValue) stack[--top];
-                                stack[top++] = new LongValue(v1.value >>> v2.value);
+                                int v2 = (int) pStack[--top];
+                                long v1 = pStack[--top];
+                                pStack[top] = v1 >>> v2;
+                                tStack[top] = T_LONG;
+                                top++;
                                 pc++;
                             }
                             case Bytecodes.INT_BIT_OR -> {
-                                var v2 = (IntValue) stack[--top];
-                                var v1 = (IntValue) stack[--top];
-                                stack[top++] = new IntValue(v1.value | v2.value);
+                                int v2 = (int) pStack[--top];
+                                int v1 = (int) pStack[--top];
+                                pStack[top] = v1 | v2;
+                                tStack[top] = T_INT;
+                                top++;
                                 pc++;
                             }
                             case Bytecodes.INT_BIT_AND -> {
-                                var v2 = (IntValue) stack[--top];
-                                var v1 = (IntValue) stack[--top];
-                                stack[top++] = new IntValue(v1.value & v2.value);
+                                int v2 = (int) pStack[--top];
+                                int v1 = (int) pStack[--top];
+                                pStack[top] = v1 & v2;
+                                tStack[top] = T_INT;
+                                top++;
                                 pc++;
                             }
                             case Bytecodes.INT_BIT_XOR -> {
-                                var v2 = (IntValue) stack[--top];
-                                var v1 = (IntValue) stack[--top];
-                                stack[top++] = new IntValue(v1.value ^ v2.value);
+                                int v2 = (int) pStack[--top];
+                                int v1 = (int) pStack[--top];
+                                pStack[top] = v1 ^ v2;
+                                tStack[top] = T_INT;
+                                top++;
                                 pc++;
                             }
                             case Bytecodes.LONG_BIT_OR -> {
-                                var v2 = (LongValue) stack[--top];
-                                var v1 = (LongValue) stack[--top];
-                                stack[top++] = new LongValue(v1.value | v2.value);
+                                long v2 = pStack[--top];
+                                long v1 = pStack[--top];
+                                pStack[top] = v1 | v2;
+                                tStack[top] = T_LONG;
+                                top++;
                                 pc++;
                             }
                             case Bytecodes.LONG_BIT_AND -> {
-                                var v2 = (LongValue) stack[--top];
-                                var v1 = (LongValue) stack[--top];
-                                stack[top++] = new LongValue(v1.value & v2.value);
+                                long v2 = pStack[--top];
+                                long v1 = pStack[--top];
+                                pStack[top] = v1 & v2;
+                                tStack[top] = T_LONG;
+                                top++;
                                 pc++;
                             }
                             case Bytecodes.LONG_BIT_XOR -> {
-                                var v2 = (LongValue) stack[--top];
-                                var v1 = (LongValue) stack[--top];
-                                stack[top++] = new LongValue(v1.value ^ v2.value);
+                                long v2 = pStack[--top];
+                                long v1 = pStack[--top];
+                                pStack[top] = v1 ^ v2;
+                                tStack[top] = T_LONG;
+                                top++;
                                 pc++;
                             }
+
+                            // --- Negation: zero allocation, pStack only ---
                             case Bytecodes.INT_NEG -> {
-                                var v = (IntValue) stack[--top];
-                                stack[top++] = new IntValue(-v.value);
+                                pStack[top - 1] = -((int) pStack[top - 1]);
+                                tStack[top - 1] = T_INT;
                                 pc++;
                             }
                             case Bytecodes.LONG_NEG -> {
-                                var v = (LongValue) stack[--top];
-                                stack[top++] = new LongValue(-v.value);
+                                pStack[top - 1] = -pStack[top - 1];
+                                tStack[top - 1] = T_LONG;
                                 pc++;
                             }
                             case Bytecodes.DOUBLE_NEG -> {
-                                var v = (DoubleValue) stack[--top];
-                                stack[top++] = new DoubleValue(-v.value);
+                                pStack[top - 1] = Double.doubleToRawLongBits(-Double.longBitsToDouble(pStack[top - 1]));
+                                tStack[top - 1] = T_DOUBLE;
                                 pc++;
                             }
                             case Bytecodes.FLOAT_NEG -> {
-                                var v = (FloatValue) stack[--top];
-                                stack[top++] = new FloatValue(-v.value);
+                                pStack[top - 1] = Float.floatToRawIntBits(-Float.intBitsToFloat((int) pStack[top - 1]));
+                                tStack[top - 1] = T_FLOAT;
                                 pc++;
                             }
-                            case Bytecodes.LONG_TO_DOUBLE -> {
-                                var v = (LongValue) stack[--top];
-                                stack[top++] = new DoubleValue(v.value);
-                                pc++;
-                            }
-                            case Bytecodes.DOUBLE_TO_LONG -> {
-                                var v = (DoubleValue) stack[--top];
-                                stack[top++] = new LongValue((long) v.value);
-                                pc++;
-                            }
+
+                            // --- Type conversions: zero allocation, pStack only ---
                             case Bytecodes.INT_TO_LONG -> {
-                                var v = (IntValue) stack[--top];
-                                stack[top++] = new LongValue(v.value);
-                                pc++;
-                            }
-                            case Bytecodes.INT_TO_CHAR -> {
-                                var v = (IntValue) stack[--top];
-                                stack[top++] = new IntValue((char) v.value);
-                                pc++;
-                            }
-                            case Bytecodes.INT_TO_SHORT -> {
-                                var v = (IntValue) stack[--top];
-                                stack[top++] = new IntValue((short) v.value);
-                                pc++;
-                            }
-                            case Bytecodes.INT_TO_BYTE -> {
-                                var v = (IntValue) stack[--top];
-                                stack[top++] = new IntValue((byte) v.value);
-                                pc++;
-                            }
-                            case Bytecodes.LONG_TO_INT -> {
-                                var v = (LongValue) stack[--top];
-                                stack[top++] = new IntValue((int) v.value);
+                                // pStack already holds the widened int as long
+                                tStack[top - 1] = T_LONG;
                                 pc++;
                             }
                             case Bytecodes.INT_TO_DOUBLE -> {
-                                var v = (IntValue) stack[--top];
-                                stack[top++] = new DoubleValue(v.value);
-                                pc++;
-                            }
-                            case Bytecodes.DOUBLE_TO_INT -> {
-                                var v = (DoubleValue) stack[--top];
-                                stack[top++] = new IntValue((int) v.value);
+                                pStack[top - 1] = Double.doubleToRawLongBits((double) (int) pStack[top - 1]);
+                                tStack[top - 1] = T_DOUBLE;
                                 pc++;
                             }
                             case Bytecodes.INT_TO_FLOAT -> {
-                                var v = (IntValue) stack[--top];
-                                stack[top++] = new FloatValue((float) v.value);
+                                pStack[top - 1] = Float.floatToRawIntBits((float) (int) pStack[top - 1]);
+                                tStack[top - 1] = T_FLOAT;
+                                pc++;
+                            }
+                            case Bytecodes.INT_TO_CHAR -> {
+                                pStack[top - 1] = (char) (int) pStack[top - 1];
+                                pc++;
+                            }
+                            case Bytecodes.INT_TO_SHORT -> {
+                                pStack[top - 1] = (short) (int) pStack[top - 1];
+                                pc++;
+                            }
+                            case Bytecodes.INT_TO_BYTE -> {
+                                pStack[top - 1] = (byte) (int) pStack[top - 1];
+                                pc++;
+                            }
+                            case Bytecodes.LONG_TO_INT -> {
+                                pStack[top - 1] = (int) pStack[top - 1];
+                                tStack[top - 1] = T_INT;
+                                pc++;
+                            }
+                            case Bytecodes.LONG_TO_DOUBLE -> {
+                                pStack[top - 1] = Double.doubleToRawLongBits((double) pStack[top - 1]);
+                                tStack[top - 1] = T_DOUBLE;
                                 pc++;
                             }
                             case Bytecodes.LONG_TO_FLOAT -> {
-                                var v = (LongValue) stack[--top];
-                                stack[top++] = new FloatValue((float) v.value);
+                                pStack[top - 1] = Float.floatToRawIntBits((float) pStack[top - 1]);
+                                tStack[top - 1] = T_FLOAT;
+                                pc++;
+                            }
+                            case Bytecodes.DOUBLE_TO_INT -> {
+                                pStack[top - 1] = (int) Double.longBitsToDouble(pStack[top - 1]);
+                                tStack[top - 1] = T_INT;
+                                pc++;
+                            }
+                            case Bytecodes.DOUBLE_TO_LONG -> {
+                                pStack[top - 1] = (long) Double.longBitsToDouble(pStack[top - 1]);
+                                tStack[top - 1] = T_LONG;
                                 pc++;
                             }
                             case Bytecodes.DOUBLE_TO_FLOAT -> {
-                                var v = (DoubleValue) stack[--top];
-                                stack[top++] = new FloatValue((float) v.value);
+                                pStack[top - 1] = Float.floatToRawIntBits((float) Double.longBitsToDouble(pStack[top - 1]));
+                                tStack[top - 1] = T_FLOAT;
                                 pc++;
                             }
                             case Bytecodes.FLOAT_TO_INT -> {
-                                var v = (FloatValue) stack[--top];
-                                stack[top++] = new IntValue((int) v.value);
+                                pStack[top - 1] = (int) Float.intBitsToFloat((int) pStack[top - 1]);
+                                tStack[top - 1] = T_INT;
                                 pc++;
                             }
                             case Bytecodes.FLOAT_TO_LONG -> {
-                                var v = (FloatValue) stack[--top];
-                                stack[top++] = new LongValue((long) v.value);
+                                pStack[top - 1] = (long) Float.intBitsToFloat((int) pStack[top - 1]);
+                                tStack[top - 1] = T_LONG;
                                 pc++;
                             }
                             case Bytecodes.FLOAT_TO_DOUBLE -> {
-                                var v = (FloatValue) stack[--top];
-                                stack[top++] = new DoubleValue(v.value);
+                                pStack[top - 1] = Double.doubleToRawLongBits((double) Float.intBitsToFloat((int) pStack[top - 1]));
+                                tStack[top - 1] = T_DOUBLE;
                                 pc++;
                             }
+
+                            // --- Comparisons on int result: zero allocation, pStack only ---
                             case Bytecodes.EQ -> {
-                                var v = ((IntValue) stack[--top]).value;
-                                stack[top++] = v == 0 ? one : zero;
+                                pStack[top - 1] = (int) pStack[top - 1] == 0 ? 1 : 0;
+                                tStack[top - 1] = T_INT;
                                 pc++;
                             }
                             case Bytecodes.NE -> {
-                                var v = ((IntValue) stack[--top]).value;
-                                stack[top++] = v != 0 ? one : zero;
+                                pStack[top - 1] = (int) pStack[top - 1] != 0 ? 1 : 0;
+                                tStack[top - 1] = T_INT;
                                 pc++;
                             }
                             case Bytecodes.GE -> {
-                                var v = ((IntValue) stack[--top]).value;
-                                stack[top++] = v >= 0 ? one : zero;
+                                pStack[top - 1] = (int) pStack[top - 1] >= 0 ? 1 : 0;
+                                tStack[top - 1] = T_INT;
                                 pc++;
                             }
                             case Bytecodes.GT -> {
-                                var v = ((IntValue) stack[--top]).value;
-                                stack[top++] = v > 0 ? one : zero;
+                                pStack[top - 1] = (int) pStack[top - 1] > 0 ? 1 : 0;
+                                tStack[top - 1] = T_INT;
                                 pc++;
                             }
                             case Bytecodes.LT -> {
-                                var v = ((IntValue) stack[--top]).value;
-                                stack[top++] = v < 0 ? one : zero;
+                                pStack[top - 1] = (int) pStack[top - 1] < 0 ? 1 : 0;
+                                tStack[top - 1] = T_INT;
                                 pc++;
                             }
                             case Bytecodes.LE -> {
-                                var v = ((IntValue) stack[--top]).value;
-                                stack[top++] = v <= 0 ? one : zero;
+                                pStack[top - 1] = (int) pStack[top - 1] <= 0 ? 1 : 0;
+                                tStack[top - 1] = T_INT;
                                 pc++;
                             }
                             case Bytecodes.INT_COMPARE -> {
-                                var v2 = ((IntValue) stack[--top]).value;
-                                var v1 = ((IntValue) stack[--top]).value;
-                                var r = (v1 < v2) ? -1 : ((v1 == v2) ? 0 : 1);
-                                stack[top++] = new IntValue(r);
+                                int v2 = (int) pStack[--top];
+                                int v1 = (int) pStack[--top];
+                                pStack[top] = (v1 < v2) ? -1 : ((v1 == v2) ? 0 : 1);
+                                tStack[top] = T_INT;
+                                top++;
                                 pc++;
                             }
                             case Bytecodes.LONG_COMPARE -> {
-                                var v2 = ((LongValue) stack[--top]).value;
-                                var v1 = ((LongValue) stack[--top]).value;
-                                var r = (v1 < v2) ? -1 : ((v1 == v2) ? 0 : 1);
-                                stack[top++] = new IntValue(r);
+                                long v2 = pStack[--top];
+                                long v1 = pStack[--top];
+                                pStack[top] = (v1 < v2) ? -1 : ((v1 == v2) ? 0 : 1);
+                                tStack[top] = T_INT;
+                                top++;
                                 pc++;
                             }
                             case Bytecodes.DOUBLE_COMPARE -> {
-                                var v2 = ((DoubleValue) stack[--top]).value;
-                                var v1 = ((DoubleValue) stack[--top]).value;
-                                var r = (v1 < v2) ? -1 : ((v1 == v2) ? 0 : 1);
-                                stack[top++] = new IntValue(r);
+                                double v2 = Double.longBitsToDouble(pStack[--top]);
+                                double v1 = Double.longBitsToDouble(pStack[--top]);
+                                pStack[top] = (v1 < v2) ? -1 : ((v1 == v2) ? 0 : 1);
+                                tStack[top] = T_INT;
+                                top++;
                                 pc++;
                             }
                             case Bytecodes.FLOAT_COMPARE -> {
-                                var v2 = ((FloatValue) stack[--top]).value;
-                                var v1 = ((FloatValue) stack[--top]).value;
-                                var r = (v1 < v2) ? -1 : ((v1 == v2) ? 0 : 1);
-                                stack[top++] = new IntValue(r);
+                                float v2 = Float.intBitsToFloat((int) pStack[--top]);
+                                float v1 = Float.intBitsToFloat((int) pStack[--top]);
+                                pStack[top] = (v1 < v2) ? -1 : ((v1 == v2) ? 0 : 1);
+                                tStack[top] = T_INT;
+                                top++;
                                 pc++;
                             }
                             case Bytecodes.REF_COMPARE_EQ -> {
-                                var v2 = (Value) stack[--top];
-                                var v1 = (Value) stack[--top];
-                                stack[top++] = v1.equals(v2) ? one : zero;
+                                var v2 = ensureValue(--top);
+                                var v1 = ensureValue(--top);
+                                pStack[top] = v1.equals(v2) ? 1 : 0;
+                                tStack[top] = T_INT;
+                                top++;
                                 pc++;
                             }
                             case Bytecodes.REF_COMPARE_NE -> {
-                                var v2 = (Value) stack[--top];
-                                var v1 = (Value) stack[--top];
-                                stack[top++] = !v1.equals(v2) ? one : zero;
+                                var v2 = ensureValue(--top);
+                                var v1 = ensureValue(--top);
+                                pStack[top] = !v1.equals(v2) ? 1 : 0;
+                                tStack[top] = T_INT;
+                                top++;
                                 pc++;
                             }
+
+                            // --- Field access ---
                             case Bytecodes.GET_FIELD -> {
                                 var i = stack[--top].resolveMvObject();
                                 var p = (FieldRef) constants[(bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff];
-                                stack[top++] = i.fields[p.getRawField().offset].value.toStackValue();
+                                var fieldValue = i.fields[p.getRawField().offset].value.toStackValue();
+                                pushValue(top, fieldValue);
+                                top++;
                                 pc += 3;
                             }
                             case Bytecodes.GET_METHOD -> {
                                 var i = stack[--top].resolveObject();
                                 var methodRef = (MethodRef) constants[(bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff];
-                                stack[top++] = i.getFunction(methodRef);
+                                stack[top] = i.getFunction(methodRef);
+                                tStack[top] = T_REF;
+                                top++;
                                 pc += 3;
                             }
                             case Bytecodes.GET_STATIC_FIELD -> {
                                 var fieldRef = (FieldRef) constants[(bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff];
                                 var staticFieldTable = StaticFieldTable.getInstance(fieldRef.getDeclaringType(), ContextUtil.getEntityContext());
-                                stack[top++] = staticFieldTable.get(fieldRef.getRawField()).toStackValue();
+                                var fieldValue = staticFieldTable.get(fieldRef.getRawField()).toStackValue();
+                                pushValue(top, fieldValue);
+                                top++;
                                 pc += 3;
                             }
                             case Bytecodes.GET_STATIC_METHOD -> {
                                 var methodRef = (MethodRef) constants[(bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff];
-                                stack[top++] = new FlowValue(methodRef, null);
+                                stack[top] = new FlowValue(methodRef, null);
+                                tStack[top] = T_REF;
+                                top++;
                                 pc += 3;
                             }
                             case Bytecodes.INSTANCE_OF -> {
-                                var v = stack[--top];
+                                var v = ensureValue(--top);
                                 var targetType = (Type) constants[(bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff];
-                                stack[top++] = targetType.isInstance(v) ? one : zero;
+                                pStack[top] = targetType.isInstance(v) ? 1 : 0;
+                                tStack[top] = T_INT;
+                                top++;
                                 pc += 3;
                             }
                             case Bytecodes.ARRAY_LENGTH -> {
                                 var a = stack[--top].resolveArray();
-                                stack[top++] = new IntValue(a.length());
+                                pStack[top] = a.length();
+                                tStack[top] = T_INT;
+                                top++;
                                 pc++;
                             }
+
+                            // --- Local variable access: mirror both stacks ---
                             case Bytecodes.STORE -> {
                                 var index = (bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff;
-                                var v = stack[--top];
-                                stack[base + index] = v;
+                                --top;
+                                int slot = base + index;
+                                stack[slot] = stack[top];
+                                pStack[slot] = pStack[top];
+                                tStack[slot] = tStack[top];
                                 pc += 3;
                             }
                             case Bytecodes.LOAD -> {
                                 var index = (bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff;
-                                stack[top++] = stack[base + index];
+                                int slot = base + index;
+                                stack[top] = stack[slot];
+                                pStack[top] = pStack[slot];
+                                tStack[top] = tStack[slot];
+                                top++;
                                 pc += 3;
                             }
                             case Bytecodes.LOAD_CONTEXT_SLOT -> {
                                 var contextIndex = (bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff;
                                 var slotIndex = (bytes[pc + 3] & 0xff) << 8 | bytes[pc + 4] & 0xff;
-                                stack[top++] = Objects.requireNonNull(closureContext).get(contextIndex, slotIndex);
+                                var v = Objects.requireNonNull(closureContext).get(contextIndex, slotIndex);
+                                pushValue(top, v);
+                                top++;
                                 pc += 5;
                             }
                             case Bytecodes.STORE_CONTEXT_SLOT -> {
                                 var contextIndex = (bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff;
                                 var slotIndex = (bytes[pc + 3] & 0xff) << 8 | bytes[pc + 4] & 0xff;
-                                Objects.requireNonNull(closureContext).set(contextIndex, slotIndex, stack[--top]);
+                                Objects.requireNonNull(closureContext).set(contextIndex, slotIndex, ensureValue(--top));
                                 pc += 5;
                             }
                             case Bytecodes.LOAD_CONSTANT -> {
                                 var value = (Value) constants[(bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff];
-                                stack[top++] = value;
+                                pushValue(top, value);
+                                top++;
                                 pc += 3;
                             }
                             case Bytecodes.NEW_ARRAY_WITH_DIMS -> {
@@ -1057,10 +1288,12 @@ public class VmStack {
                                 var dimensions = (bytes[pc + 3] & 0xff) << 8 | bytes[pc + 4] & 0xff;
                                 var dims = new int[dimensions];
                                 for (int i = dimensions - 1; i >= 0; i--) {
-                                    dims[i] = ((IntValue) stack[--top]).value;
+                                    dims[i] = (int) pStack[--top];
                                 }
                                 Instances.initArray(array, dims, 0);
-                                stack[top++] = array.getReference();
+                                stack[top] = array.getReference();
+                                tStack[top] = T_REF;
+                                top++;
                                 pc += 5;
                             }
                             case Bytecodes.VOID_RETURN -> {
@@ -1083,15 +1316,26 @@ public class VmStack {
                                 constants = callableRef.getTypeMetadata().getValues();
                                 closureContext = frame.closureContext;
                             }
+
+                            // --- Stack manipulation: mirror both stacks ---
                             case Bytecodes.DUP -> {
-                                stack[top] = stack[top++ - 1];
+                                stack[top] = stack[top - 1];
+                                pStack[top] = pStack[top - 1];
+                                tStack[top] = tStack[top - 1];
+                                top++;
                                 pc++;
                             }
                             case Bytecodes.DUP2 -> {
-                                var v1 = stack[top - 2];
-                                var v2 = stack[top - 1];
-                                stack[top++] = v1;
-                                stack[top++] = v2;
+                                int d2a = top - 2;
+                                int d2b = top - 1;
+                                stack[top] = stack[d2a];
+                                pStack[top] = pStack[d2a];
+                                tStack[top] = tStack[d2a];
+                                top++;
+                                stack[top] = stack[d2b];
+                                pStack[top] = pStack[d2b];
+                                tStack[top] = tStack[d2b];
+                                top++;
                                 pc++;
                             }
                             case Bytecodes.POP -> {
@@ -1099,38 +1343,64 @@ public class VmStack {
                                 pc++;
                             }
                             case Bytecodes.DUP_X1 -> {
-                                var v = stack[top] = stack[top - 1];
+                                // Copy top element
+                                stack[top] = stack[top - 1];
+                                pStack[top] = pStack[top - 1];
+                                tStack[top] = tStack[top - 1];
+                                // Move second-from-top up
                                 stack[top - 1] = stack[top - 2];
-                                stack[top - 2] = v;
+                                pStack[top - 1] = pStack[top - 2];
+                                tStack[top - 1] = tStack[top - 2];
+                                // Insert copy at third position
+                                stack[top - 2] = stack[top];
+                                pStack[top - 2] = pStack[top];
+                                tStack[top - 2] = tStack[top];
                                 top++;
                                 pc++;
                             }
                             case Bytecodes.DUP_X2 -> {
-                                var v = stack[top] = stack[top - 1];
+                                // Copy top element
+                                stack[top] = stack[top - 1];
+                                pStack[top] = pStack[top - 1];
+                                tStack[top] = tStack[top - 1];
+                                // Shift down
                                 stack[top - 1] = stack[top - 2];
+                                pStack[top - 1] = pStack[top - 2];
+                                tStack[top - 1] = tStack[top - 2];
                                 stack[top - 2] = stack[top - 3];
-                                stack[top - 3] = v;
+                                pStack[top - 2] = pStack[top - 3];
+                                tStack[top - 2] = tStack[top - 3];
+                                // Insert copy at fourth position
+                                stack[top - 3] = stack[top];
+                                pStack[top - 3] = pStack[top];
+                                tStack[top - 3] = tStack[top];
                                 top++;
                                 pc++;
                             }
                             case Bytecodes.LOAD_PARENT -> {
                                 var v = stack[--top];
                                 var idx = (bytes[pc + 1] & 0xff) << 8 | (bytes[pc + 2] & 0xff);
-                                stack[top++] = requireNonNull(v.resolveMvObject().getParent(idx)).getReference();
+                                stack[top] = requireNonNull(v.resolveMvObject().getParent(idx)).getReference();
+                                tStack[top] = T_REF;
+                                top++;
                                 pc += 3;
                             }
                             case Bytecodes.LOAD_CHILDREN -> {
                                 var v = stack[--top];
-                                stack[top++] = Instances.arrayValue(Utils.map(v.resolveMvObject().getChildren(), Instance::getReference));
+                                stack[top] = Instances.arrayValue(Utils.map(v.resolveMvObject().getChildren(), Instance::getReference));
+                                tStack[top] = T_REF;
+                                top++;
                                 pc++;
                             }
                             case Bytecodes.ID -> {
                                 var v = stack[--top];
-                                stack[top++] = Instances.stringInstance(v.resolveMvObject().getStringId());
+                                stack[top] = Instances.stringInstance(v.resolveMvObject().getStringId());
+                                tStack[top] = T_REF;
+                                top++;
                                 pc++;
                             }
                             case Bytecodes.TABLE_SWITCH -> {
-                                var k = ((IntValue) stack[--top]).value;
+                                int k = (int) pStack[--top];
                                 int p = pc + 4 & 0xfffffffc;
                                 int defaultOffset = (bytes[p] & 0xff) << 24 | (bytes[p + 1] & 0xff) << 16
                                         | (bytes[p + 2] & 0xff) << 8 | bytes[p + 3] & 0xff;
@@ -1149,7 +1419,7 @@ public class VmStack {
                                 pc += offset;
                             }
                             case Bytecodes.LOOKUP_SWITCH -> {
-                                var k = ((IntValue) stack[--top]).value;
+                                int k = (int) pStack[--top];
                                 int p = pc + 4 & 0xfffffffc;
                                 int offset = (bytes[p] & 0xff) << 24 | (bytes[p + 1] & 0xff) << 16
                                         | (bytes[p + 2] & 0xff) << 8 | bytes[p + 3] & 0xff;
@@ -1180,7 +1450,7 @@ public class VmStack {
                             case Bytecodes.SET_FIELD_REFRESH -> {
                                 int fieldIndex = (bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff;
                                 var field = (FieldRef) constants[fieldIndex];
-                                var value = stack[--top];
+                                var value = ensureValue(--top);
                                 var instance = stack[--top].resolveMvObject();
                                 instance.fields[field.getRawField().offset].value = field.getPropertyType().fromStackValue(value);
                                 if (instance.isInitialized())
@@ -1210,7 +1480,9 @@ public class VmStack {
                             constants = callableRef.getTypeMetadata().getValues();
                             closureContext = f.closureContext;
                         }
-                        stack[top++] = exception.getReference();
+                        stack[top] = exception.getReference();
+                        tStack[top] = T_REF;
+                        top++;
                     }
                     else {
                         Arrays.fill(stack, 0, base + code.getFrameSize(), null);
@@ -1227,8 +1499,6 @@ public class VmStack {
                 }
             }
         } finally {
-//            if(DebugEnv.flag)
-//                log.debug("Exiting flow {}", scope.getFlow().getQualifiedName());
         }
     }
 

--- a/model/src/main/java/org/manul/object/instance/core/IntValue.java
+++ b/model/src/main/java/org/manul/object/instance/core/IntValue.java
@@ -9,11 +9,27 @@ import org.manul.util.WireTypes;
 @Slf4j
 public class IntValue extends NumberValue {
 
-    public static final IntValue zero = new IntValue(0);
+    private static final int CACHE_LOW = -128;
+    private static final int CACHE_HIGH = 128;
+    private static final IntValue[] CACHE = new IntValue[CACHE_HIGH - CACHE_LOW + 1];
 
-    public static final IntValue one = new IntValue(1);
+    static {
+        for (int i = 0; i < CACHE.length; i++) {
+            CACHE[i] = new IntValue(i + CACHE_LOW);
+        }
+    }
 
-    public static final IntValue minusOne = new IntValue(-1);
+    public static IntValue of(int value) {
+        if (value >= CACHE_LOW && value <= CACHE_HIGH)
+            return CACHE[value - CACHE_LOW];
+        return new IntValue(value);
+    }
+
+    public static final IntValue zero = CACHE[-CACHE_LOW];
+
+    public static final IntValue one = CACHE[1 - CACHE_LOW];
+
+    public static final IntValue minusOne = CACHE[-1 - CACHE_LOW];
 
     public final int value;
 

--- a/test/src/test/java/org/manul/compiler/VmStackPoolBugTest.java
+++ b/test/src/test/java/org/manul/compiler/VmStackPoolBugTest.java
@@ -1,0 +1,178 @@
+package org.manul.compiler;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Assert;
+import org.manul.flow.VmStack;
+import org.manul.object.instance.core.Value;
+import org.manul.util.ApiNamedObject;
+import org.manul.util.ObjectPool;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.List;
+
+/**
+ * Regression test for stale tStack entries in pooled VmStack instances.
+ * <p>
+ * The VmStack RETURN/VOID_RETURN handlers clear {@code stack[]} via
+ * {@code Arrays.fill(stack, base, base + frameSize, null)} but do NOT
+ * clear {@code tStack[]} or {@code pStack[]}. When the VmStack is
+ * returned to the pool and later reused, the stale type tags in
+ * {@code tStack[]} cause {@code ensureValue()} to materialize values
+ * from stale {@code pStack[]} data instead of returning null from
+ * cleared {@code stack[]} slots.
+ */
+@Slf4j
+public class VmStackPoolBugTest extends ManulTestBase {
+
+    /**
+     * Verifies that after a VmStack executes int-heavy bytecode and is
+     * returned to the pool, its tStack contains stale non-zero type tags
+     * in slots where stack[] has been cleared to null.
+     * <p>
+     * With the bug: tStack has stale T_INT/T_LONG/etc entries, causing
+     * ensureValue() to materialize phantom values from stale pStack data.
+     * <p>
+     * After the fix: tStack is cleared alongside stack[], so ensureValue()
+     * correctly returns null for cleared slots.
+     */
+    @SuppressWarnings("unchecked")
+    public void testStaleTStackInPooledVmStack() throws Exception {
+        // Deploy a Manul class with an int-heavy bean method
+        deploy("manul/vmstack_pool_bug.mnl");
+
+        var bean = ApiNamedObject.of("vmStackPoolBugLab");
+
+        // Call the int-heavy method multiple times to ensure a VmStack
+        // with stale T_INT entries is in the pool
+        for (int i = 0; i < 5; i++) {
+            callMethod(bean, "intHeavy", List.of(3, 4));
+        }
+
+        // Access the VmStack pool via reflection
+        Field poolField = VmStack.class.getDeclaredField("pool");
+        poolField.setAccessible(true);
+        ObjectPool<Object> pool = (ObjectPool<Object>) poolField.get(null);
+
+        // Borrow a VmStack from the pool
+        Object vmStack = pool.borrowObject();
+        Assert.assertNotNull("Pool should have a VmStack after method execution", vmStack);
+
+        try {
+            // Access the internal arrays via reflection
+            Field stackField = VmStack.class.getDeclaredField("stack");
+            stackField.setAccessible(true);
+            Value[] stack = (Value[]) stackField.get(vmStack);
+
+            Field tStackField = VmStack.class.getDeclaredField("tStack");
+            tStackField.setAccessible(true);
+            byte[] tStack = (byte[]) tStackField.get(vmStack);
+
+            // Look for slots where tStack has a stale non-zero type tag
+            // (T_INT=1, T_LONG=2, T_DOUBLE=3, T_FLOAT=4) but stack[] is null
+            // (cleared by RETURN's Arrays.fill).
+            // These are the dangerous slots: ensureValue() will read the stale
+            // tStack tag and materialize a phantom value from stale pStack data.
+            int stalePrimitiveCount = 0;
+            int firstStaleSlot = -1;
+            for (int i = 0; i < 1024; i++) {
+                if (tStack[i] != 0 && stack[i] == null) {
+                    stalePrimitiveCount++;
+                    if (firstStaleSlot == -1) {
+                        firstStaleSlot = i;
+                    }
+                }
+            }
+
+            // THE BUG: After RETURN clears stack[] but NOT tStack[],
+            // stale primitive type tags remain. Any subsequent execution
+            // reusing this VmStack could read these stale tags via ensureValue().
+            Assert.assertEquals(
+                    "Expected tStack to be fully cleared (no stale primitive tags) " +
+                    "in slots where stack[] is null, but found " + stalePrimitiveCount +
+                    " stale entries. First stale slot: " + firstStaleSlot +
+                    " with tStack=" + (firstStaleSlot >= 0 ? tStack[firstStaleSlot] : "N/A") +
+                    ". The RETURN handler must clear tStack[] alongside stack[].",
+                    0,
+                    stalePrimitiveCount
+            );
+        } finally {
+            pool.returnObject(vmStack);
+        }
+    }
+
+    /**
+     * Verifies that ensureValue() on a stale slot returns a phantom value
+     * materialized from stale pStack data, instead of null.
+     * <p>
+     * This directly demonstrates the consequence of the stale tStack bug:
+     * ensureValue() trusts the stale type tag and creates a value from
+     * garbage pStack data, rather than returning the actual stack[] value (null).
+     */
+    @SuppressWarnings("unchecked")
+    public void testEnsureValueReturnsPhantomOnStaleSlot() throws Exception {
+        deploy("manul/vmstack_pool_bug.mnl");
+
+        var bean = ApiNamedObject.of("vmStackPoolBugLab");
+
+        // Execute int-heavy code to poison tStack
+        for (int i = 0; i < 5; i++) {
+            callMethod(bean, "intHeavy", List.of(10, 20));
+        }
+
+        // Access the pool and borrow a VmStack
+        Field poolField = VmStack.class.getDeclaredField("pool");
+        poolField.setAccessible(true);
+        ObjectPool<Object> pool = (ObjectPool<Object>) poolField.get(null);
+
+        Object vmStack = pool.borrowObject();
+        Assert.assertNotNull(vmStack);
+
+        try {
+            Field stackField = VmStack.class.getDeclaredField("stack");
+            stackField.setAccessible(true);
+            Value[] stack = (Value[]) stackField.get(vmStack);
+
+            Field tStackField = VmStack.class.getDeclaredField("tStack");
+            tStackField.setAccessible(true);
+            byte[] tStack = (byte[]) tStackField.get(vmStack);
+
+            // Find a slot with stale T_INT and null stack
+            int staleSlot = -1;
+            for (int i = 0; i < 1024; i++) {
+                if (tStack[i] == 1 /* T_INT */ && stack[i] == null) {
+                    staleSlot = i;
+                    break;
+                }
+            }
+
+            if (staleSlot == -1) {
+                // No stale T_INT found - if the fix is applied, this is expected.
+                // Test passes.
+                return;
+            }
+
+            // Call ensureValue() via reflection on the stale slot
+            Method ensureValue = VmStack.class.getDeclaredMethod("ensureValue", int.class);
+            ensureValue.setAccessible(true);
+
+            Value result = (Value) ensureValue.invoke(vmStack, staleSlot);
+
+            // THE BUG: ensureValue sees tStack[staleSlot] = T_INT (stale),
+            // reads pStack[staleSlot] (stale int data), and materializes
+            // an IntValue. The correct behavior is to return null because
+            // stack[staleSlot] is null (the slot was cleared by RETURN).
+            Assert.assertNull(
+                    "ensureValue() materialized a phantom value (" + result +
+                    ") from stale pStack data at slot " + staleSlot +
+                    ". The slot's stack[] is null (cleared by RETURN) but " +
+                    "tStack[] still has T_INT=" + tStack[staleSlot] +
+                    ". After the fix, tStack should be cleared to T_REF(0) " +
+                    "and ensureValue should return null.",
+                    result
+            );
+        } finally {
+            pool.returnObject(vmStack);
+        }
+    }
+}

--- a/test/src/test/resources/manul/vmstack_pool_bug.mnl
+++ b/test/src/test/resources/manul/vmstack_pool_bug.mnl
@@ -1,0 +1,20 @@
+@Bean
+class VmStackPoolBugLab {
+
+    fn intHeavy(a: int, b: int) -> int {
+        var c = a + b
+        var d = c * a
+        var e = d - b
+        var f = e + c
+        var g = f + d
+        var h = g + e
+        var i = h + f
+        var j = i + g
+        return j
+    }
+
+    fn returnString(s: string) -> string {
+        return s
+    }
+
+}


### PR DESCRIPTION
## Summary
- Replace the single `Value[]` stack with a dual-stack architecture (`long[] pStack` + `Value[] stack` + `byte[] tStack`) to eliminate heap allocation in arithmetic, comparison, conversion, and branch opcodes.
- Add `IntValue.of(int)` factory with a -128..128 cache for reduced allocation at materialization boundaries.

## Test plan
- [x] All 562 existing tests pass with zero failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)