### PR TITLE
feat(vm): dual stack optimization for VmStack

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -150,10 +150,18 @@ The `meta` module runs annotation processors during Java compilation that transf
 
 ## Recent Changes
 
-**Circular static init fix** (Feb 2026):
-- Fixed `__klass__` field in EntityTransformer from eager to lazy initialization
-- Root cause: circular `<clinit>` chain between Type, Klass, AnyType classes
-- Manifested only on Temurin JDK 21 (CI), not GraalVM (local)
+**Dual Stack VM** (Feb 2026, uncommitted):
+- Added parallel `long[] pstack` + `byte[] ptag` arrays to `VmStack` alongside `Value[] stack`
+- Primitives (int/long/float/double) stored as raw bits, eliminating boxing in arithmetic/comparison/load/store ops
+- Bridge methods: `unboxTo()` (Value→pstack), `ensureBoxed()` (pstack→Value), `boxFromTag()` (factory)
+- Boxing only at boundaries: native method calls, field access, closure capture, type checks
+- All bytecode handlers converted; 595 tests pass with zero regressions
+- See `.claude/docs/architecture.md` "VmStack — Dual Stack VM Interpreter" for full details
+
+**PR #120**: Aliyun OSS release uploads + circular static init fix (Feb 2026)
+- Replaced Gitee uploads with Aliyun OSS (37s vs 30+ min)
+- Fixed `__klass__` lazy init in EntityTransformer (circular `<clinit>` between Type/Klass/AnyType)
+- Added ES rebuild-index endpoint, deployment scripts, .claude docs
 
 **PR #117**: Fix API child object updates
 **PR #116**: REST-Compliant API (removed `/api` prefix, plural nouns, PATCH with ID)

--- a/.claude/docs/architecture.md
+++ b/.claude/docs/architecture.md
@@ -115,7 +115,72 @@ Type (interface)
 
 **CFG**: Directed graph of `Node` objects. `BranchNode` (true/false), `GotoNode`, `ReturnNode`.
 
-**Execution**: Stack-based VM, ~10x slower than JIT-compiled JVM, fast startup.
+**Execution**: Stack-based VM with dual-stack optimization (see below), ~10x slower than JIT-compiled JVM, fast startup.
+
+#### VmStack — Dual Stack VM Interpreter (`org.manul.flow.VmStack`)
+
+The bytecode interpreter is a single giant `switch` inside an infinite `for(;;)` loop, processing one bytecode per iteration. VmStack instances are **pooled** via `ObjectPool<VmStack>` (max 1024) to avoid reallocating the large internal arrays.
+
+**Dual Stack Architecture**: The VM uses three parallel arrays per stack slot instead of a single `Value[]`:
+
+```java
+Value[] stack  = new Value[1M];   // object references (strings, entities, arrays, etc.)
+long[]  pstack = new long[1M];    // primitive bits (int/long/float/double stored as raw bits)
+byte[]  ptag   = new byte[1M];    // type tag per slot: TAG_OBJ=0, TAG_INT=1, TAG_LONG=2, TAG_FLOAT=3, TAG_DOUBLE=4
+```
+
+Each slot `i` is typed by `ptag[i]`. When `TAG_OBJ`, the value is in `stack[i]`. When `TAG_INT/LONG/FLOAT/DOUBLE`, the value is in `pstack[i]` as raw bits (float/double via `Float.floatToRawIntBits`/`Double.doubleToRawLongBits`), and `stack[i]` is null.
+
+**Purpose**: Eliminates boxing overhead. Before this, every `INT_ADD` allocated a `new IntValue(...)` on the heap. With the dual stack, pure-primitive loops (arithmetic, comparisons, variable load/store) produce zero garbage.
+
+**Three bridge methods** handle the boundary between primitive and object worlds:
+- `unboxTo(i, Value v)` — Object→Primitive: pattern-matches on IntValue/LongValue/FloatValue/DoubleValue, stores raw bits in `pstack[i]`, sets `ptag[i]`, nulls `stack[i]`. Non-primitive values go into `stack[i]` with `TAG_OBJ`.
+- `ensureBoxed(i)` — Primitive→Object: if `ptag[i] != TAG_OBJ`, materializes the boxed Value into `stack[i]` via `boxFromTag()`.
+- `boxFromTag(tag, bits)` — Static factory: `TAG_INT → new IntValue((int)bits)`, `TAG_FLOAT → new FloatValue(Float.intBitsToFloat((int)bits))`, etc.
+
+**When boxing is required** (calls to `ensureBoxed`/`ensureBoxedRange`):
+- Before passing args to native methods (they expect `Value[]`)
+- Before storing into entity fields (`SET_FIELD`, `SET_STATIC`, `SET_ELEMENT`, `ADD_ELEMENT`)
+- Before capturing closure context (`NEW`, `NEW_CHILD`, `LAMBDA` with local types)
+- Before storing into `ClosureContext` (`STORE_CONTEXT_SLOT`)
+- Before `CAST` and `INSTANCE_OF` (need to inspect Value type)
+- Before `REF_COMPARE_EQ`/`REF_COMPARE_NE` (need `.equals()`)
+
+**When unboxing happens** (calls to `unboxTo`):
+- At entry: arguments are unboxed into the initial frame
+- `LOAD_CONSTANT` — constants from the pool are unboxed
+- `LOAD_CONTEXT_SLOT` — closure values unboxed on read
+- `GET_FIELD`, `GET_STATIC_FIELD` — field values unboxed after `.toStackValue()`
+- `GET_ELEMENT` — array element unboxed after `.toStackValue()`
+- Native method return values unboxed
+- `CAST` result re-unboxed after type check
+
+**Bytecode transformation patterns**:
+
+1. *Pure arithmetic* (INT/LONG/FLOAT/DOUBLE_ADD/SUB/MUL/DIV/REM/NEG): Read/write `pstack` directly, zero allocation.
+2. *Variable access* (LOAD/STORE): Copy all three components (`stack[i]`, `pstack[i]`, `ptag[i]`) since slot type is unknown statically. Same for DUP/DUP2/DUP_X1/DUP_X2.
+3. *Comparisons* (EQ/NE/LT/LE/GT/GE, INT/LONG/FLOAT/DOUBLE_COMPARE): Read from `pstack`, push int result (0 or 1, or -1/0/1) to `pstack` with `TAG_INT`.
+4. *Branches* (IF_EQ/IF_NE): Read `(int) pstack[--top]`, branch on 0.
+5. *RETURN*: Saves retTag/retPrim/retObj before `Arrays.fill` cleanup; restores all three into caller frame. At top-level (`fp==0`), boxes via `boxFromTag` for the `FlowExecResult`.
+6. *VOID_RETURN*: Now also `Arrays.fill(ptag, base, ..., TAG_OBJ)` to reset tags.
+7. *Method invocation* (INVOKE_VIRTUAL/SPECIAL/STATIC/FUNCTION, FUNC): For bytecode callees, adds `Arrays.fill(ptag, argsEnd, top, TAG_OBJ)` to initialize new frame's unused local tags. For native callees, `ensureBoxed` before call, `unboxTo` after return.
+8. *Exception handling*: Cross-frame unwind now also cleans `ptag[]`. Exception ref pushed as `TAG_OBJ`.
+9. *NON_NULL optimization*: Short-circuits when `ptag[top-1] != TAG_OBJ` (primitives can never be null).
+
+**Frame record**: `Frame(int pc, int base, int top, CallableRef callableRef, ClosureContext closureContext)` — unchanged by dual stack (primitive state is already in the shared arrays, indexed by base/top).
+
+**Memory footprint**: Each VmStack instance uses ~17MB (8MB `long[1M]` + 1MB `byte[1M]` + 8MB `Value[1M]`). With pooling, only active concurrent executions consume memory.
+
+#### Value Type Hierarchy (`org.manul.object.instance.core.*`)
+
+The `toStackValue()` / `fromStackValue()` methods bridge between storage representation and stack representation:
+
+- **IntValue, LongValue, FloatValue, DoubleValue**: `toStackValue()` returns `this`. These are the four types that get unboxed into `pstack`.
+- **BooleanValue**: `toStackValue()` → `IntValue(1)` or `IntValue(0)`. Booleans are ints on the stack.
+- **ByteValue, ShortValue, CharValue**: `toStackValue()` → `IntValue(value)`. Sub-int types promote to int on the stack (like JVM).
+- **Non-primitives** (StringReference, EntityReference, ArrayInstance, NullValue, etc.): Stay as `Value` objects with `TAG_OBJ`.
+
+`fromStackValue()` does the reverse for field storage: `PrimitiveKind.BOOLEAN` converts `IntValue(0/1)` back to `BooleanValue`, `CHAR` converts `IntValue` back to `CharValue`, etc.
 
 #### Entity/Persistence Layer
 

--- a/.claude/docs/debugging.md
+++ b/.claude/docs/debugging.md
@@ -80,6 +80,15 @@ Types.getAnyType() → AnyType extends Type
 - Malformed bytecode can crash VM
 - Compiler guarantees correctness
 
+### 14. Dual Stack Tag Consistency
+- Every stack slot has three components: `stack[i]`, `pstack[i]`, `ptag[i]`
+- When `ptag[i] == TAG_OBJ`, the value is in `stack[i]` and `pstack[i]` is garbage
+- When `ptag[i] != TAG_OBJ`, the value is in `pstack[i]` and `stack[i]` MUST be null (to avoid retaining dead object references in the pooled VmStack)
+- Any operation that moves values of unknown type (LOAD, STORE, DUP, DUP_X1, DUP_X2, DUP2, RETURN) must copy all three components
+- Forgetting to `ensureBoxed()` before passing to native methods or field stores will cause ClassCastException or wrong values
+- Forgetting `Arrays.fill(ptag, ..., TAG_OBJ)` when initializing new frame locals or cleaning up on return will leave stale tags from previous executions (VmStack is pooled)
+- `ensureBoxedRange(base, top)` is required before closure capture since `ClosureContext` stores `Value[]`
+
 ### 9. Exception Handling Overhead
 - `TRY_ENTER`/`TRY_EXIT` bytecodes add stack frame overhead
 - Nested try blocks compound the cost
@@ -129,3 +138,13 @@ Types.getAnyType() → AnyType extends Type
 **Docker testing** (for CI reproduction):
 - `Dockerfile.test` exists for running tests in ubuntu+JDK21 environment
 - Requires Docker daemon running: `docker build -f Dockerfile.test -t manul-test . && docker run manul-test`
+
+**workflow_dispatch won't trigger from feature branches**:
+- GitHub only allows `workflow_dispatch` for workflows registered on the default branch
+- Workaround: add test jobs (with `if: github.event_name == 'workflow_dispatch'`) to the existing workflow file instead of creating new workflow files on feature branches
+
+**Release workflow not triggering after tag push**:
+- `release-asset-upload.yml` triggers on `release: types: [created]`, NOT on tag push
+- Pushing a tag alone does nothing — must create a GitHub Release via `gh release create` or the GitHub UI
+- If an old release exists for the same tag, delete it first: `gh release delete TAG --yes`
+- Stale draft releases become "untagged" when their tag is deleted; they must be explicitly deleted

--- a/.claude/docs/operations.md
+++ b/.claude/docs/operations.md
@@ -81,9 +81,10 @@ launchctl load ~/Library/LaunchAgents/com.manul.server.plist
 
 **Architecture**:
 - Merge to `main` does NOT auto-deploy
-- Deployment triggered by recreating `0.0.1-alpha` release tag
+- Deployment triggered by recreating `0.0.1-alpha` **GitHub Release** (not just a tag!)
 - GitHub Actions builds native images (Mac, Linux, Windows, Alpine)
 - Artifacts uploaded to GitHub Releases and Aliyun OSS
+- **Critical**: The release workflow triggers on `release: types: [created]`, NOT on tag push. Must use `gh release create` or create via GitHub UI.
 
 **Git Workflow**:
 - Feature branches rebased against `origin/main`
@@ -110,6 +111,12 @@ Flags: `--skip-tests`, `--skip-pr`, `--skip-deploy`
 
 Steps: verify main + clean → pull latest → delete `0.0.1-alpha` tag → recreate at HEAD → push.
 
+**Important**: `deploy.sh` only pushes the tag. You must also create a GitHub Release to trigger the build workflow:
+```bash
+gh release delete 0.0.1-alpha --yes 2>/dev/null
+gh release create 0.0.1-alpha --title "0.0.1-alpha" --notes "Release 0.0.1-alpha" --prerelease
+```
+
 ### Manual Process
 
 ```bash
@@ -121,23 +128,27 @@ git push -u origin feat/my-feature --force-with-lease
 gh pr create --base main --head feat/my-feature --fill
 gh pr merge feat/my-feature --squash --delete-branch
 
-# 2. Deploy
+# 2. Deploy (must create release, not just tag)
 git checkout main && git pull origin main
 git tag -d 0.0.1-alpha && git push origin :refs/tags/0.0.1-alpha
 git tag -a 0.0.1-alpha -m "Release 0.0.1-alpha - $(date +%Y-%m-%d)"
 git push origin 0.0.1-alpha
+gh release delete 0.0.1-alpha --yes 2>/dev/null
+gh release create 0.0.1-alpha --title "0.0.1-alpha" --notes "Release 0.0.1-alpha - $(date +%Y-%m-%d)" --prerelease
 ```
 
 ### GitHub Actions Workflows
 
 **ci.yml**: PR/push to main → `mvn -B verify` → Temurin JDK 21
 
-**release-asset-upload.yml**: Release/tag → native images (macOS aarch64/amd64, Windows amd64, Linux amd64/aarch64, Alpine amd64/aarch64) → GraalVM native-image → upload to GitHub Releases + Aliyun OSS. Build time: ~4 minutes.
+**release-asset-upload.yml**: `release: types: [created]` → native images (macOS aarch64/amd64, Windows amd64, Linux amd64/aarch64, Alpine amd64/aarch64) → GraalVM native-image → upload to GitHub Releases + Aliyun OSS. Build time: ~12 min (macOS slowest). Also triggers on `workflow_dispatch` and push to `working` branch (for testing).
+
+**Gotcha**: `workflow_dispatch` can only trigger workflows registered on the default branch. To test workflow changes, add test jobs to the existing workflow file rather than creating new workflow files on feature branches.
 
 ### Deployment Checklist
 
 Before: tests pass, code reviewed, changes documented, migrations prepared.
-After: verify build (~4 min), check GitHub Release, verify OSS artifacts, test download.
+After: verify build (~12 min), check GitHub Release, verify OSS artifacts, test download.
 
 ---
 
@@ -205,11 +216,20 @@ Problem: Accidentally cleared ES data for app 1000061024. Resolution: data intac
 **URLs**:
 ```
 https://pkg.metavm.tech/releases/0.0.1-alpha/manul-{platform}.tar.gz
-https://pkg.metavm.tech/releases/latest/manul-{platform}.tar.gz
 ```
+Note: No `/latest/` path currently — only tag-versioned paths are uploaded.
 
 **GitHub Secrets**: `ALIYUN_ACCESS_KEY_ID`, `ALIYUN_ACCESS_KEY_SECRET`
 
-**Performance**: OSS upload ~2 min (vs Gitee ~30+ min, 15x faster).
+**Performance** (measured Feb 2026 with real native images):
+- Upload speed: ~7.5-9 MB/s per file from GitHub Actions runners
+- Total: ~37 seconds for 7 artifacts (~244 MB) — vs Gitee ~30+ min (30x faster)
+- Artifact sizes: Linux/Alpine ~29-30 MB, macOS ~38 MB, Windows ~39 MB
+
+**ossutil notes**:
+- Installed via: `curl -sL https://gosspublic.alicdn.com/ossutil/install.sh | sudo bash` (installs v1.7.19)
+- Auth: `ossutil config -e ENDPOINT -i KEY_ID -k KEY_SECRET -L CH` (v1 syntax, NOT env vars)
+- Upload: `ossutil cp FILE oss://BUCKET/PATH -f`
+- The `ossutil64` direct binary URL is dead; always use the install script
 
 **Setup**: `./setup-aliyun-oss.py` — creates bucket, configures DNS, sets CORS, creates directories.

--- a/model/src/main/java/org/manul/flow/VmStack.java
+++ b/model/src/main/java/org/manul/flow/VmStack.java
@@ -18,8 +18,6 @@ import org.manul.util.*;
 import java.util.*;
 
 import static java.util.Objects.requireNonNull;
-import static org.manul.object.instance.core.IntValue.one;
-import static org.manul.object.instance.core.IntValue.zero;
 
 @Slf4j
 public class VmStack {
@@ -41,9 +39,52 @@ public class VmStack {
 
     private final ExceptionHandler[] exceptionHandlers = new ExceptionHandler[1024];
     private final Value[] stack = new Value[1024 * 1024];
+    private final long[] pstack = new long[1024 * 1024];
+    private final byte[] ptag = new byte[1024 * 1024];
     private final Frame[] frames = new Frame[1024];
 
+    private static final byte TAG_OBJ = 0;
+    private static final byte TAG_INT = 1;
+    private static final byte TAG_LONG = 2;
+    private static final byte TAG_FLOAT = 3;
+    private static final byte TAG_DOUBLE = 4;
+
     private VmStack() {
+    }
+
+    private void ensureBoxed(int i) {
+        if (ptag[i] != TAG_OBJ) {
+            stack[i] = boxFromTag(ptag[i], pstack[i]);
+            ptag[i] = TAG_OBJ;
+        }
+    }
+
+    private void ensureBoxedRange(int from, int to) {
+        for (int i = from; i < to; i++) ensureBoxed(i);
+    }
+
+    private static Value boxFromTag(byte tag, long bits) {
+        return switch (tag) {
+            case TAG_INT -> new IntValue((int) bits);
+            case TAG_LONG -> new LongValue(bits);
+            case TAG_FLOAT -> new FloatValue(Float.intBitsToFloat((int) bits));
+            case TAG_DOUBLE -> new DoubleValue(Double.longBitsToDouble(bits));
+            default -> throw new IllegalStateException();
+        };
+    }
+
+    private void unboxTo(int i, Value v) {
+        if (v instanceof IntValue iv) {
+            pstack[i] = iv.value; ptag[i] = TAG_INT; stack[i] = null;
+        } else if (v instanceof LongValue lv) {
+            pstack[i] = lv.value; ptag[i] = TAG_LONG; stack[i] = null;
+        } else if (v instanceof FloatValue fv) {
+            pstack[i] = Float.floatToRawIntBits(fv.value); ptag[i] = TAG_FLOAT; stack[i] = null;
+        } else if (v instanceof DoubleValue dv) {
+            pstack[i] = Double.doubleToRawLongBits(dv.value); ptag[i] = TAG_DOUBLE; stack[i] = null;
+        } else {
+            stack[i] = v; ptag[i] = TAG_OBJ;
+        }
     }
 
     @SuppressWarnings({"DuplicatedCode", "UseCompareMethod", "DataFlowIssue", "ExtractMethodRecommender"})
@@ -63,10 +104,14 @@ public class VmStack {
             var constants = callableRef.getTypeMetadata().getValues();
             System.arraycopy(arguments, 0, stack, 0, arguments.length);
             var stack = this.stack;
+            var pstack = this.pstack;
+            var ptag = this.ptag;
             var frames = this.frames;
             int base = 0;
             var code = callableRef.getCode();
             int top = code.getMaxLocals();
+            for (int i = 0; i < arguments.length; i++) unboxTo(i, arguments[i]);
+            Arrays.fill(ptag, arguments.length, top, TAG_OBJ);
             int handlerTop = 0;
             int pc = 0;
             var bytes = code.getCode();
@@ -91,31 +136,34 @@ public class VmStack {
                                 var fieldValues = new LinkedList<Value>();
                                 var fields = type.getKlass().getAllFields();
                                 int numFields = fields.size();
+                                ensureBoxedRange(top - numFields, top);
                                 for (int i = 0; i < numFields; i++) {
                                     fieldValues.addFirst(stack[--top]);
                                 }
                                 Utils.biForEach(fields, fieldValues, (f, v) -> instance.initField(f, f.getType().fromStackValue(v)));
                                 if (!instance.isEphemeral())
                                     callContext.instanceRepository().bind(instance);
-                                stack[top++] = instance.getReference();
+                                stack[top] = instance.getReference(); ptag[top++] = TAG_OBJ;
                                 pc += 4;
                             }
                             case Bytecodes.SET_FIELD -> {
                                 int fieldIndex = (bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff;
                                 var field = (FieldRef) constants[fieldIndex];
+                                ensureBoxed(top - 1);
                                 var value = stack[--top];
                                 var instance = stack[--top].resolveMvObject();
                                 instance.fields[field.getRawField().offset].value = field.getPropertyType().fromStackValue(value);
                                 pc += 3;
                             }
                             case Bytecodes.RETURN -> {
-                                var v = stack[top - 1];
+                                var retTag = ptag[top - 1]; var retPrim = pstack[top - 1]; var retObj = stack[top - 1];
                                 Arrays.fill(stack, base, base + code.getFrameSize(), null);
+                                Arrays.fill(ptag, base, base + code.getFrameSize(), TAG_OBJ);
                                 if (fp == 0)
-                                    return FlowExecResult.of(v);
+                                    return FlowExecResult.of(retTag != TAG_OBJ ? boxFromTag(retTag, retPrim) : retObj);
                                 var frame = frames[--fp];
                                 frames[fp] = null;
-                                stack[frame.top] = v;
+                                stack[frame.top] = retObj; pstack[frame.top] = retPrim; ptag[frame.top] = retTag;
                                 pc = frame.pc;
                                 top = frame.top + 1;
                                 base = frame.base;
@@ -138,6 +186,7 @@ public class VmStack {
                                     method = ((ClassType) requireNonNull(self).getValueType()).getOverride(method);
                                 if (method.isNative()) {
                                     var paramCount = method.getParameterCount();
+                                    for (int i = top - paramCount; i < top; i++) ensureBoxed(i);
                                     var args = new Value[paramCount];
                                     for (int i = paramCount - 1; i >= 0; i--) {
                                         args[i] = stack[--top];
@@ -147,12 +196,16 @@ public class VmStack {
                                     if (r.exception() != null) {
                                         exception = r.exception();
                                         break except;
-                                    } else if (!method.getReturnType().isVoid())
-                                        stack[top++] = r.ret();
+                                    } else if (!method.getReturnType().isVoid()) {
+                                        unboxTo(top, r.ret());
+                                        top++;
+                                    }
                                 } else {
                                     int prevBase = base;
+                                    int argsEnd = top;
                                     base = top - method.getParameterCount() - 1;
                                     top = base + method.getRawFlow().getCode().getMaxLocals();
+                                    if (argsEnd < top) Arrays.fill(ptag, argsEnd, top, TAG_OBJ);
                                     frames[fp++] = new Frame(pc, prevBase, base, callableRef, closureContext);
                                     callableRef = method;
                                     code = method.getRawFlow().getCode();
@@ -178,6 +231,7 @@ public class VmStack {
                                     method = ((ClassType) requireNonNull(self).getValueType()).getOverride(method);
                                 if (method.isNative()) {
                                     var paramCount = method.getParameterCount();
+                                    for (int i = top - paramCount; i < top; i++) ensureBoxed(i);
                                     var args = new Value[paramCount];
                                     for (int i = paramCount - 1; i >= 0; i--) {
                                         args[i] = stack[--top];
@@ -187,12 +241,16 @@ public class VmStack {
                                     if (r.exception() != null) {
                                         exception = r.exception();
                                         break except;
-                                    } else if (!method.getReturnType().isVoid())
-                                        stack[top++] = r.ret();
+                                    } else if (!method.getReturnType().isVoid()) {
+                                        unboxTo(top, r.ret());
+                                        top++;
+                                    }
                                 } else {
                                     int prevBase = base;
+                                    int argsEnd = top;
                                     base = top - method.getParameterCount() - 1;
                                     top = base + method.getRawFlow().getCode().getMaxLocals();
+                                    if (argsEnd < top) Arrays.fill(ptag, argsEnd, top, TAG_OBJ);
                                     frames[fp++] = new Frame(pc, prevBase, base, callableRef, closureContext);
                                     callableRef = method;
                                     code = method.getRawFlow().getCode();
@@ -209,6 +267,7 @@ public class VmStack {
                                 var self = stack[top - method.getParameterCount() - 1];
                                 if (method.isNative()) {
                                     var paramCount = method.getParameterCount();
+                                    for (int i = top - paramCount; i < top; i++) ensureBoxed(i);
                                     var args = new Value[paramCount];
                                     for (int i = paramCount - 1; i >= 0; i--) {
                                         args[i] = stack[--top];
@@ -218,12 +277,16 @@ public class VmStack {
                                     if (r.exception() != null) {
                                         exception = r.exception();
                                         break except;
-                                    } else if (!method.getReturnType().isVoid())
-                                        stack[top++] = r.ret();
+                                    } else if (!method.getReturnType().isVoid()) {
+                                        unboxTo(top, r.ret());
+                                        top++;
+                                    }
                                 } else {
                                     int prevBase = base;
+                                    int argsEnd = top;
                                     base = top - method.getParameterCount() - 1;
                                     top = base + method.getRawFlow().getCode().getMaxLocals();
+                                    if (argsEnd < top) Arrays.fill(ptag, argsEnd, top, TAG_OBJ);
                                     frames[fp++] = new Frame(pc, prevBase, base, callableRef, closureContext);
                                     callableRef = method;
                                     code = method.getRawFlow().getCode();
@@ -247,6 +310,7 @@ public class VmStack {
                                 var self = stack[top - method.getParameterCount() - 1];
                                 if (method.isNative()) {
                                     var paramCount = method.getParameterCount();
+                                    for (int i = top - paramCount; i < top; i++) ensureBoxed(i);
                                     var args = new Value[paramCount];
                                     for (int i = paramCount - 1; i >= 0; i--) {
                                         args[i] = stack[--top];
@@ -256,12 +320,16 @@ public class VmStack {
                                     if (r.exception() != null) {
                                         exception = r.exception();
                                         break except;
-                                    } else if (!method.getReturnType().isVoid())
-                                        stack[top++] = r.ret();
+                                    } else if (!method.getReturnType().isVoid()) {
+                                        unboxTo(top, r.ret());
+                                        top++;
+                                    }
                                 } else {
                                     int prevBase = base;
+                                    int argsEnd = top;
                                     base = top - method.getParameterCount() - 1;
                                     top = base + method.getRawFlow().getCode().getMaxLocals();
+                                    if (argsEnd < top) Arrays.fill(ptag, argsEnd, top, TAG_OBJ);
                                     frames[fp++] = new Frame(pc, prevBase, base, callableRef, closureContext);
                                     callableRef = method;
                                     code = method.getRawFlow().getCode();
@@ -277,6 +345,7 @@ public class VmStack {
                                 pc += 3;
                                 if (method.isNative()) {
                                     var paramCount = method.getParameterCount();
+                                    for (int i = top - paramCount; i < top; i++) ensureBoxed(i);
                                     var args = new Value[paramCount];
                                     for (int i = paramCount - 1; i >= 0; i--) {
                                         args[i] = stack[--top];
@@ -285,12 +354,16 @@ public class VmStack {
                                     if (r.exception() != null) {
                                         exception = r.exception();
                                         break except;
-                                    } else if (!method.getReturnType().isVoid())
-                                        stack[top++] = r.ret();
+                                    } else if (!method.getReturnType().isVoid()) {
+                                        unboxTo(top, r.ret());
+                                        top++;
+                                    }
                                 } else {
                                     int prevBase = base;
+                                    int argsEnd = top;
                                     base = top - method.getParameterCount();
                                     top = base + method.getRawFlow().getCode().getMaxLocals();
+                                    if (argsEnd < top) Arrays.fill(ptag, argsEnd, top, TAG_OBJ);
                                     frames[fp++] = new Frame(pc, prevBase, base, callableRef, closureContext);
                                     callableRef = method;
                                     code = method.getRawFlow().getCode();
@@ -313,6 +386,7 @@ public class VmStack {
                                 var method = new MethodRef(declaringType, m, List.of(typeArgs));
                                 if (method.isNative()) {
                                     var paramCount = method.getParameterCount();
+                                    for (int i = top - paramCount; i < top; i++) ensureBoxed(i);
                                     var args = new Value[paramCount];
                                     for (int i = paramCount - 1; i >= 0; i--) {
                                         args[i] = stack[--top];
@@ -321,12 +395,16 @@ public class VmStack {
                                     if (r.exception() != null) {
                                         exception = r.exception();
                                         break except;
-                                    } else if (!method.getReturnType().isVoid())
-                                        stack[top++] = r.ret();
+                                    } else if (!method.getReturnType().isVoid()) {
+                                        unboxTo(top, r.ret());
+                                        top++;
+                                    }
                                 } else {
                                     int prevBase = base;
+                                    int argsEnd = top;
                                     base = top - method.getParameterCount();
                                     top = base + method.getRawFlow().getCode().getMaxLocals();
+                                    if (argsEnd < top) Arrays.fill(ptag, argsEnd, top, TAG_OBJ);
                                     frames[fp++] = new Frame(pc, prevBase, base, callableRef, closureContext);
                                     callableRef = method;
                                     code = method.getRawFlow().getCode();
@@ -341,7 +419,7 @@ public class VmStack {
                                 Value result = callContext.instanceRepository().selectFirstByKey(loadIndexKey(index, stack[--top]));
                                 if (result == null)
                                     result = new NullValue();
-                                stack[top++] = result;
+                                stack[top] = result; ptag[top++] = TAG_OBJ;
                                 pc += 3;
                             }
                             case Bytecodes.NEW -> {
@@ -349,28 +427,31 @@ public class VmStack {
                                 var type = (ClassType) constants[typeIndex];
                                 var ephemeral = bytes[pc + 3] == 1;
                                 var unbound = bytes[pc + 4] == 1;
+                                if (type.isLocal()) ensureBoxedRange(base, top);
                                 var self = ClassInstanceBuilder.newBuilder(type, repository.allocateRootId(type))
                                         .ephemeral(ephemeral)
                                         .closureContext(type.isLocal() ? new ClosureContext(closureContext, Arrays.copyOfRange(stack, base, top)) : null)
                                         .build();
                                 if (!self.isEphemeral() && !unbound)
                                     callContext.instanceRepository().bind(self);
-                                stack[top++] = self.getReference();
+                                stack[top] = self.getReference(); ptag[top++] = TAG_OBJ;
                                 pc += 5;
                             }
                             case Bytecodes.NEW_CHILD -> {
                                 var typeIndex = (bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff;
                                 var type = (ClassType) constants[typeIndex];
                                 var parent = stack[--top].resolveObject();
+                                if (type.isLocal()) ensureBoxedRange(base, top + 1);
                                 var self = ClassInstanceBuilder.newBuilder(type, parent.getRoot().nextChildId())
                                         .parent(parent)
                                         .closureContext(type.isLocal() ? new ClosureContext(closureContext, Arrays.copyOfRange(stack, base, top + 1)) : null)
                                         .build();
-                                stack[top++] = self.getReference();
+                                stack[top] = self.getReference(); ptag[top++] = TAG_OBJ;
                                 pc += 3;
                             }
                             case Bytecodes.SET_STATIC -> {
                                 var field = (FieldRef) constants[(bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff];
+                                ensureBoxed(top - 1);
                                 var sft = StaticFieldTable.getInstance(field.getDeclaringType(), ContextUtil.getEntityContext());
                                 sft.set(field.getRawField(), stack[--top]);
                                 pc += 3;
@@ -378,7 +459,7 @@ public class VmStack {
                             case Bytecodes.NEW_ARRAY -> {
                                 // TODO support ephemeral
                                 var array = new ArrayInstance((ArrayType) constants[(bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff]);
-                                stack[top++] = array.getReference();
+                                stack[top] = array.getReference(); ptag[top++] = TAG_OBJ;
                                 pc += 3;
                             }
                             case Bytecodes.TRY_ENTER -> {
@@ -394,6 +475,7 @@ public class VmStack {
                                 var functionType = (FunctionType) constants[(bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff];
                                 pc += 3;
                                 int prevBase = base;
+                                int savedTop = top;
                                 int prevTop = top - functionType.getParameterTypes().size() - 1;
                                 var funcInst = (FunctionValue) stack[prevTop];
                                 var self = funcInst.getSelf();
@@ -402,6 +484,7 @@ public class VmStack {
                                 else
                                     base = prevTop + 1;
                                 top = base + funcInst.getCode().getMaxLocals();
+                                if (savedTop < top) Arrays.fill(ptag, savedTop, top, TAG_OBJ);
                                 frames[fp++] = new Frame(pc, prevBase, prevTop, callableRef, closureContext);
                                 callableRef = funcInst;
                                 code = funcInst.getCode();
@@ -412,9 +495,10 @@ public class VmStack {
                             }
                             case Bytecodes.LAMBDA -> {
                                 var lambda = (LambdaRef) constants[(bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff];
+                                ensureBoxedRange(base, top);
                                 var func = new LambdaValue(lambda, new ClosureContext(closureContext, Arrays.copyOfRange(stack, base, top)));
                                 if (bytes[pc + 3] == 0) {
-                                    stack[top++] = func;
+                                    stack[top] = func; ptag[top++] = TAG_OBJ;
                                     pc += 4;
                                 } else {
                                     var functionalInterface = (ClassType) constants[bytes[pc + 4] | bytes[pc + 5]];
@@ -422,28 +506,31 @@ public class VmStack {
                                     var functionInterfaceImpl = Types.createFunctionalClass(functionalInterface);
                                     var funcImplKlass = functionInterfaceImpl.getKlass();
                                     var funcField = funcImplKlass.getFieldByName("func");
-                                    stack[top++] = ClassInstance.create(TmpId.random(), Map.of(funcField, func), functionInterfaceImpl).getReference();
+                                    stack[top] = ClassInstance.create(TmpId.random(), Map.of(funcField, func), functionInterfaceImpl).getReference(); ptag[top++] = TAG_OBJ;
                                     pc += 6;
                                 }
                             }
                             case Bytecodes.ADD_ELEMENT -> {
+                                ensureBoxed(top - 1);
                                 var e = stack[--top];
                                 var a = stack[--top].resolveArray();
                                 a.addElement(a.getInstanceType().getElementType().fromStackValue(e));
                                 pc++;
                             }
                             case Bytecodes.DELETE_ELEMENT -> {
+                                ensureBoxed(top - 1);
                                 var elem = stack[--top];
                                 var array = stack[--top].resolveArray();
                                 var r = array.remove(elem);
-                                stack[top++] = Instances.intInstance(r);
+                                stack[top] = null; pstack[top] = r ? 1 : 0; ptag[top++] = TAG_INT;
                                 pc++;
                             }
                             case Bytecodes.GET_ELEMENT -> {
-                                var index = ((IntValue) stack[--top]).value;
+                                var index = (int) pstack[--top];
                                 var arrayInst = stack[--top].resolveArray();
                                 if (index < arrayInst.size()) {
-                                    stack[top++] = arrayInst.get(index).toStackValue();
+                                    unboxTo(top, arrayInst.get(index).toStackValue());
+                                    top++;
                                     pc++;
                                 } else {
                                     exception = ClassInstance.allocate(TmpId.random(), StdKlass.exception.type());
@@ -457,6 +544,7 @@ public class VmStack {
                                 pc += 3;
                                 if (func.isNative()) {
                                     var paramCount = func.getParameterCount();
+                                    for (int i = top - paramCount; i < top; i++) ensureBoxed(i);
                                     var args = new Value[paramCount];
                                     for (int i = paramCount - 1; i >= 0; i--) {
                                         args[i] = stack[--top];
@@ -466,12 +554,16 @@ public class VmStack {
                                     if (r.exception() != null) {
                                         exception = r.exception();
                                         break except;
-                                    } else if (!func.getReturnType().isVoid())
-                                        stack[top++] = r.ret();
+                                    } else if (!func.getReturnType().isVoid()) {
+                                        unboxTo(top, r.ret());
+                                        top++;
+                                    }
                                 } else {
                                     int prevBase = base;
+                                    int argsEnd = top;
                                     base = top - func.getParameterCount();
                                     top = base + func.getRawFlow().getCode().getMaxLocals();
+                                    if (argsEnd < top) Arrays.fill(ptag, argsEnd, top, TAG_OBJ);
                                     frames[fp++] = new Frame(pc, prevBase, base, callableRef, closureContext);
                                     callableRef = func;
                                     code = func.getRawFlow().getCode();
@@ -493,6 +585,7 @@ public class VmStack {
                                 var func = new FunctionRef(f, List.of(typeArgs));
                                 if (func.isNative()) {
                                     var paramCount = func.getParameterCount();
+                                    for (int i = top - paramCount; i < top; i++) ensureBoxed(i);
                                     var args = new Value[paramCount];
                                     for (int i = paramCount - 1; i >= 0; i--) {
                                         args[i] = stack[--top];
@@ -502,12 +595,16 @@ public class VmStack {
                                     if (r.exception() != null) {
                                         exception = r.exception();
                                         break except;
-                                    } else if (!func.getReturnType().isVoid())
-                                        stack[top++] = r.ret();
+                                    } else if (!func.getReturnType().isVoid()) {
+                                        unboxTo(top, r.ret());
+                                        top++;
+                                    }
                                 } else {
                                     int prevBase = base;
+                                    int argsEnd = top;
                                     base = top - func.getParameterCount();
                                     top = base + func.getRawFlow().getCode().getMaxLocals();
+                                    if (argsEnd < top) Arrays.fill(ptag, argsEnd, top, TAG_OBJ);
                                     frames[fp++] = new Frame(pc, prevBase, base, callableRef, closureContext);
                                     callableRef = func;
                                     code = func.getRawFlow().getCode();
@@ -518,13 +615,16 @@ public class VmStack {
                                 }
                             }
                             case Bytecodes.CAST -> {
+                                ensureBoxed(top - 1);
                                 var inst = stack[--top];
                                 var type = (Type) constants[(bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff];
                                 if (type.isInstance(inst)) {
-                                    stack[top++] = inst;
+                                    unboxTo(top, inst);
+                                    top++;
                                     pc += 3;
                                 } else if (type.isAssignableFrom(inst.getValueType())) {
-                                    stack[top++] = inst;
+                                    unboxTo(top, inst);
+                                    top++;
                                     pc += 3;
                                 } else {
                                     exception = ClassInstance.allocate(TmpId.random(), StdKlass.exception.get().getType());
@@ -542,7 +642,7 @@ public class VmStack {
                             case Bytecodes.COPY -> {
                                 var sourceInst = stack[--top];
                                 var copy = sourceInst.resolveMv().copy(repository::allocateRootId);
-                                stack[top++] = copy.getReference();
+                                stack[top] = copy.getReference(); ptag[top++] = TAG_OBJ;
                                 pc++;
                             }
                             case Bytecodes.INDEX_SCAN -> {
@@ -552,7 +652,7 @@ public class VmStack {
                                 var from = loadIndexKey(index, stack[--top]);
                                 var result = callContext.instanceRepository().indexScan(from, to);
                                 var type = new ArrayType(index.getDeclaringType(), ArrayKind.READ_ONLY);
-                                stack[top++] = new ArrayInstance(type, result).getReference();
+                                stack[top] = new ArrayInstance(type, result).getReference(); ptag[top++] = TAG_OBJ;
                                 pc += 3;
                             }
                             case Bytecodes.INDEX_COUNT -> {
@@ -561,7 +661,7 @@ public class VmStack {
                                 var to = loadIndexKey(index, stack[--top]);
                                 var from = loadIndexKey(index, stack[--top]);
                                 var count = callContext.instanceRepository().indexCount(from, to);
-                                stack[top++] = new LongValue(count);
+                                stack[top] = null; pstack[top] = count; ptag[top++] = TAG_LONG;
                                 pc += 3;
                             }
                             case Bytecodes.INDEX_SELECT -> {
@@ -569,18 +669,19 @@ public class VmStack {
                                 var result = callContext.instanceRepository().indexSelect(loadIndexKey(index, stack[--top]));
                                 var type = Types.getArrayType(index.getDeclaringType());
                                 var list = Instances.createArray(type, result);
-                                stack[top++] = list.getReference();
+                                stack[top] = list.getReference(); ptag[top++] = TAG_OBJ;
                                 pc += 3;
                             }
                             case Bytecodes.INDEX_SELECT_FIRST -> {
                                 var index = (IndexRef) constants[(bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff];
                                 var result = callContext.instanceRepository().selectFirstByKey(loadIndexKey(index, stack[--top]));
-                                stack[top++] = Utils.orElse(result, new NullValue());
+                                stack[top] = Utils.orElse(result, new NullValue()); ptag[top++] = TAG_OBJ;
                                 pc += 3;
                             }
                             case Bytecodes.NON_NULL -> {
-                                var inst = stack[top - 1];
-                                if (inst.isNull()) {
+                                if (ptag[top - 1] != TAG_OBJ) {
+                                    pc++;
+                                } else if (stack[top - 1].isNull()) {
                                     exception = ClassInstance.allocate(TmpId.random(), StdKlass.exception.type());
                                     ExceptionNative.Exception(exception, Instances.stringInstance("Null pointer"));
                                     break except;
@@ -588,467 +689,461 @@ public class VmStack {
                                     pc++;
                             }
                             case Bytecodes.SET_ELEMENT -> {
+                                ensureBoxed(top - 1);
                                 var e = stack[--top];
-                                var i = ((IntValue) stack[--top]).value;
+                                var i = (int) pstack[--top];
                                 var a = stack[--top].resolveArray();
                                 a.setElement(i, a.getInstanceType().getElementType().fromStackValue(e));
                                 pc++;
                             }
                             case Bytecodes.IF_EQ -> {
-                                if (((IntValue) stack[--top]).value == 0)
+                                if ((int) pstack[--top] == 0)
                                     pc += (short) ((bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff);
                                 else
                                     pc += 3;
                             }
                             case Bytecodes.IF_NE -> {
-                                if (((IntValue) stack[--top]).value != 0)
+                                if ((int) pstack[--top] != 0)
                                     pc += (short) ((bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff);
                                 else
                                     pc += 3;
                             }
                             case Bytecodes.GOTO -> pc += (short) ((bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff);
                             case Bytecodes.INT_ADD -> {
-                                var v2 = (IntValue) stack[--top];
-                                var v1 = (IntValue) stack[--top];
-                                stack[top++] = new IntValue(v1.value + v2.value);
+                                var v2 = (int) pstack[--top];
+                                var v1 = (int) pstack[--top];
+                                pstack[top] = v1 + v2; ptag[top++] = TAG_INT;
                                 pc++;
                             }
                             case Bytecodes.INT_SUB -> {
-                                var v2 = (IntValue) stack[--top];
-                                var v1 = (IntValue) stack[--top];
-                                stack[top++] = new IntValue(v1.value - v2.value);
+                                var v2 = (int) pstack[--top];
+                                var v1 = (int) pstack[--top];
+                                pstack[top] = v1 - v2; ptag[top++] = TAG_INT;
                                 pc++;
                             }
                             case Bytecodes.INT_MUL -> {
-                                var v2 = (IntValue) stack[--top];
-                                var v1 = (IntValue) stack[--top];
-                                stack[top++] = new IntValue(v1.value * v2.value);
+                                var v2 = (int) pstack[--top];
+                                var v1 = (int) pstack[--top];
+                                pstack[top] = v1 * v2; ptag[top++] = TAG_INT;
                                 pc++;
                             }
                             case Bytecodes.INT_DIV -> {
-                                var v2 = ((IntValue) stack[--top]).value;
-                                var v1 = ((IntValue) stack[--top]).value;
+                                var v2 = (int) pstack[--top];
+                                var v1 = (int) pstack[--top];
                                 if (v2 == 0) {
                                     exception = ClassInstance.allocate(TmpId.random(), StdKlass.exception.type());
                                     ExceptionNative.Exception(exception, Instances.stringInstance("/ by zero"));
                                     break except;
                                 } else {
-                                    stack[top++] = new IntValue(v1 / v2);
+                                    pstack[top] = v1 / v2; ptag[top++] = TAG_INT;
                                     pc++;
                                 }
                             }
                             case Bytecodes.INT_REM -> {
-                                var v2 = ((IntValue) stack[--top]).value;
-                                var v1 = ((IntValue) stack[--top]).value;
+                                var v2 = (int) pstack[--top];
+                                var v1 = (int) pstack[--top];
                                 if (v2 == 0) {
                                     exception = ClassInstance.allocate(TmpId.random(), StdKlass.exception.type());
                                     ExceptionNative.Exception(exception, Instances.stringInstance("/ by zero"));
                                     break except;
                                 } else {
-                                    stack[top++] = new IntValue(v1 % v2);
+                                    pstack[top] = v1 % v2; ptag[top++] = TAG_INT;
                                     pc++;
                                 }
                             }
                             case Bytecodes.LONG_ADD -> {
-                                var v2 = (LongValue) stack[--top];
-                                var v1 = (LongValue) stack[--top];
-                                stack[top++] = new LongValue(v1.value + v2.value);
+                                var v2 = pstack[--top];
+                                var v1 = pstack[--top];
+                                pstack[top] = v1 + v2; ptag[top++] = TAG_LONG;
                                 pc++;
                             }
                             case Bytecodes.LONG_SUB -> {
-                                var v2 = (LongValue) stack[--top];
-                                var v1 = (LongValue) stack[--top];
-                                stack[top++] = new LongValue(v1.value - v2.value);
+                                var v2 = pstack[--top];
+                                var v1 = pstack[--top];
+                                pstack[top] = v1 - v2; ptag[top++] = TAG_LONG;
                                 pc++;
                             }
                             case Bytecodes.LONG_MUL -> {
-                                var v2 = (LongValue) stack[--top];
-                                var v1 = (LongValue) stack[--top];
-                                stack[top++] = new LongValue(v1.value * v2.value);
+                                var v2 = pstack[--top];
+                                var v1 = pstack[--top];
+                                pstack[top] = v1 * v2; ptag[top++] = TAG_LONG;
                                 pc++;
                             }
                             case Bytecodes.LONG_DIV -> {
-                                var v2 = ((LongValue) stack[--top]).value;
-                                var v1 = ((LongValue) stack[--top]).value;
+                                var v2 = pstack[--top];
+                                var v1 = pstack[--top];
                                 if (v2 == 0) {
                                     exception = ClassInstance.allocate(TmpId.random(), StdKlass.exception.type());
                                     ExceptionNative.Exception(exception, Instances.stringInstance("/ by zero"));
                                     break except;
                                 } else {
-                                    stack[top++] = new LongValue(v1 / v2);
+                                    pstack[top] = v1 / v2; ptag[top++] = TAG_LONG;
                                     pc++;
                                 }
                             }
                             case Bytecodes.LONG_REM -> {
-                                var v2 = ((LongValue) stack[--top]).value;
-                                var v1 = ((LongValue) stack[--top]).value;
+                                var v2 = pstack[--top];
+                                var v1 = pstack[--top];
                                 if (v2 == 0) {
                                     exception = ClassInstance.allocate(TmpId.random(), StdKlass.exception.type());
                                     ExceptionNative.Exception(exception, Instances.stringInstance("/ by zero"));
                                     break except;
                                 } else {
-                                    stack[top++] = new LongValue(v1 % v2);
+                                    pstack[top] = v1 % v2; ptag[top++] = TAG_LONG;
                                     pc++;
                                 }
                             }
                             case Bytecodes.DOUBLE_ADD -> {
-                                var v2 = (DoubleValue) stack[--top];
-                                var v0 = stack[--top];
-                                var v1 = (DoubleValue) v0;
-                                stack[top++] = new DoubleValue(v1.value + v2.value);
+                                var v2 = Double.longBitsToDouble(pstack[--top]);
+                                var v1 = Double.longBitsToDouble(pstack[--top]);
+                                pstack[top] = Double.doubleToRawLongBits(v1 + v2); ptag[top++] = TAG_DOUBLE;
                                 pc++;
                             }
                             case Bytecodes.DOUBLE_SUB -> {
-                                var v2 = (DoubleValue) stack[--top];
-                                var v1 = (DoubleValue) stack[--top];
-                                stack[top++] = new DoubleValue(v1.value - v2.value);
+                                var v2 = Double.longBitsToDouble(pstack[--top]);
+                                var v1 = Double.longBitsToDouble(pstack[--top]);
+                                pstack[top] = Double.doubleToRawLongBits(v1 - v2); ptag[top++] = TAG_DOUBLE;
                                 pc++;
                             }
                             case Bytecodes.DOUBLE_MUL -> {
-                                var v2 = (DoubleValue) stack[--top];
-                                var v1 = (DoubleValue) stack[--top];
-                                stack[top++] = new DoubleValue(v1.value * v2.value);
+                                var v2 = Double.longBitsToDouble(pstack[--top]);
+                                var v1 = Double.longBitsToDouble(pstack[--top]);
+                                pstack[top] = Double.doubleToRawLongBits(v1 * v2); ptag[top++] = TAG_DOUBLE;
                                 pc++;
                             }
                             case Bytecodes.DOUBLE_DIV -> {
-                                var v2 = (DoubleValue) stack[--top];
-                                var v1 = (DoubleValue) stack[--top];
-                                stack[top++] = new DoubleValue(v1.value / v2.value);
+                                var v2 = Double.longBitsToDouble(pstack[--top]);
+                                var v1 = Double.longBitsToDouble(pstack[--top]);
+                                pstack[top] = Double.doubleToRawLongBits(v1 / v2); ptag[top++] = TAG_DOUBLE;
                                 pc++;
                             }
                             case Bytecodes.DOUBLE_REM -> {
-                                var v2 = (DoubleValue) stack[--top];
-                                var v1 = (DoubleValue) stack[--top];
-                                stack[top++] = new DoubleValue(v1.value % v2.value);
+                                var v2 = Double.longBitsToDouble(pstack[--top]);
+                                var v1 = Double.longBitsToDouble(pstack[--top]);
+                                pstack[top] = Double.doubleToRawLongBits(v1 % v2); ptag[top++] = TAG_DOUBLE;
                                 pc++;
                             }
                             case Bytecodes.FLOAT_ADD -> {
-                                var v2 = (FloatValue) stack[--top];
-                                var v1 = (FloatValue) stack[--top];
-                                stack[top++] = new FloatValue(v1.value + v2.value);
+                                var v2 = Float.intBitsToFloat((int) pstack[--top]);
+                                var v1 = Float.intBitsToFloat((int) pstack[--top]);
+                                pstack[top] = Float.floatToRawIntBits(v1 + v2); ptag[top++] = TAG_FLOAT;
                                 pc++;
                             }
                             case Bytecodes.FLOAT_SUB -> {
-                                var v2 = (FloatValue) stack[--top];
-                                var v1 = (FloatValue) stack[--top];
-                                stack[top++] = new FloatValue(v1.value - v2.value);
+                                var v2 = Float.intBitsToFloat((int) pstack[--top]);
+                                var v1 = Float.intBitsToFloat((int) pstack[--top]);
+                                pstack[top] = Float.floatToRawIntBits(v1 - v2); ptag[top++] = TAG_FLOAT;
                                 pc++;
                             }
                             case Bytecodes.FLOAT_MUL -> {
-                                var v2 = (FloatValue) stack[--top];
-                                var v1 = (FloatValue) stack[--top];
-                                stack[top++] = new FloatValue(v1.value * v2.value);
+                                var v2 = Float.intBitsToFloat((int) pstack[--top]);
+                                var v1 = Float.intBitsToFloat((int) pstack[--top]);
+                                pstack[top] = Float.floatToRawIntBits(v1 * v2); ptag[top++] = TAG_FLOAT;
                                 pc++;
                             }
                             case Bytecodes.FLOAT_DIV -> {
-                                var v2 = (FloatValue) stack[--top];
-                                var v1 = (FloatValue) stack[--top];
-                                stack[top++] = new FloatValue(v1.value / v2.value);
+                                var v2 = Float.intBitsToFloat((int) pstack[--top]);
+                                var v1 = Float.intBitsToFloat((int) pstack[--top]);
+                                pstack[top] = Float.floatToRawIntBits(v1 / v2); ptag[top++] = TAG_FLOAT;
                                 pc++;
                             }
                             case Bytecodes.FLOAT_REM -> {
-                                var v2 = (FloatValue) stack[--top];
-                                var v1 = (FloatValue) stack[--top];
-                                stack[top++] = new FloatValue(v1.value % v2.value);
+                                var v2 = Float.intBitsToFloat((int) pstack[--top]);
+                                var v1 = Float.intBitsToFloat((int) pstack[--top]);
+                                pstack[top] = Float.floatToRawIntBits(v1 % v2); ptag[top++] = TAG_FLOAT;
                                 pc++;
                             }
                             case Bytecodes.INT_SHIFT_LEFT -> {
-                                var v2 = (IntValue) stack[--top];
-                                var v1 = (IntValue) stack[--top];
-                                stack[top++] = new IntValue(v1.value << v2.value);
+                                var v2 = (int) pstack[--top];
+                                var v1 = (int) pstack[--top];
+                                pstack[top] = v1 << v2; ptag[top++] = TAG_INT;
                                 pc++;
                             }
                             case Bytecodes.INT_SHIFT_RIGHT -> {
-                                var v2 = (IntValue) stack[--top];
-                                var v1 = (IntValue) stack[--top];
-                                stack[top++] = new IntValue(v1.value >> v2.value);
+                                var v2 = (int) pstack[--top];
+                                var v1 = (int) pstack[--top];
+                                pstack[top] = v1 >> v2; ptag[top++] = TAG_INT;
                                 pc++;
                             }
                             case Bytecodes.INT_UNSIGNED_SHIFT_RIGHT -> {
-                                var v2 = (IntValue) stack[--top];
-                                var v1 = (IntValue) stack[--top];
-                                stack[top++] = new IntValue(v1.value >>> v2.value);
+                                var v2 = (int) pstack[--top];
+                                var v1 = (int) pstack[--top];
+                                pstack[top] = v1 >>> v2; ptag[top++] = TAG_INT;
                                 pc++;
                             }
                             case Bytecodes.LONG_SHIFT_LEFT -> {
-                                var v2 = (IntValue) stack[--top];
-                                var v1 = (LongValue) stack[--top];
-                                stack[top++] = new LongValue(v1.value << v2.value);
+                                var v2 = (int) pstack[--top];
+                                var v1 = pstack[--top];
+                                pstack[top] = v1 << v2; ptag[top++] = TAG_LONG;
                                 pc++;
                             }
                             case Bytecodes.LONG_SHIFT_RIGHT -> {
-                                var v2 = (IntValue) stack[--top];
-                                var v1 = (LongValue) stack[--top];
-                                stack[top++] = new LongValue(v1.value >> v2.value);
+                                var v2 = (int) pstack[--top];
+                                var v1 = pstack[--top];
+                                pstack[top] = v1 >> v2; ptag[top++] = TAG_LONG;
                                 pc++;
                             }
                             case Bytecodes.LONG_UNSIGNED_SHIFT_RIGHT -> {
-                                var v2 = (IntValue) stack[--top];
-                                var v1 = (LongValue) stack[--top];
-                                stack[top++] = new LongValue(v1.value >>> v2.value);
+                                var v2 = (int) pstack[--top];
+                                var v1 = pstack[--top];
+                                pstack[top] = v1 >>> v2; ptag[top++] = TAG_LONG;
                                 pc++;
                             }
                             case Bytecodes.INT_BIT_OR -> {
-                                var v2 = (IntValue) stack[--top];
-                                var v1 = (IntValue) stack[--top];
-                                stack[top++] = new IntValue(v1.value | v2.value);
+                                var v2 = (int) pstack[--top];
+                                var v1 = (int) pstack[--top];
+                                pstack[top] = v1 | v2; ptag[top++] = TAG_INT;
                                 pc++;
                             }
                             case Bytecodes.INT_BIT_AND -> {
-                                var v2 = (IntValue) stack[--top];
-                                var v1 = (IntValue) stack[--top];
-                                stack[top++] = new IntValue(v1.value & v2.value);
+                                var v2 = (int) pstack[--top];
+                                var v1 = (int) pstack[--top];
+                                pstack[top] = v1 & v2; ptag[top++] = TAG_INT;
                                 pc++;
                             }
                             case Bytecodes.INT_BIT_XOR -> {
-                                var v2 = (IntValue) stack[--top];
-                                var v1 = (IntValue) stack[--top];
-                                stack[top++] = new IntValue(v1.value ^ v2.value);
+                                var v2 = (int) pstack[--top];
+                                var v1 = (int) pstack[--top];
+                                pstack[top] = v1 ^ v2; ptag[top++] = TAG_INT;
                                 pc++;
                             }
                             case Bytecodes.LONG_BIT_OR -> {
-                                var v2 = (LongValue) stack[--top];
-                                var v1 = (LongValue) stack[--top];
-                                stack[top++] = new LongValue(v1.value | v2.value);
+                                var v2 = pstack[--top];
+                                var v1 = pstack[--top];
+                                pstack[top] = v1 | v2; ptag[top++] = TAG_LONG;
                                 pc++;
                             }
                             case Bytecodes.LONG_BIT_AND -> {
-                                var v2 = (LongValue) stack[--top];
-                                var v1 = (LongValue) stack[--top];
-                                stack[top++] = new LongValue(v1.value & v2.value);
+                                var v2 = pstack[--top];
+                                var v1 = pstack[--top];
+                                pstack[top] = v1 & v2; ptag[top++] = TAG_LONG;
                                 pc++;
                             }
                             case Bytecodes.LONG_BIT_XOR -> {
-                                var v2 = (LongValue) stack[--top];
-                                var v1 = (LongValue) stack[--top];
-                                stack[top++] = new LongValue(v1.value ^ v2.value);
+                                var v2 = pstack[--top];
+                                var v1 = pstack[--top];
+                                pstack[top] = v1 ^ v2; ptag[top++] = TAG_LONG;
                                 pc++;
                             }
                             case Bytecodes.INT_NEG -> {
-                                var v = (IntValue) stack[--top];
-                                stack[top++] = new IntValue(-v.value);
+                                pstack[top - 1] = -(int) pstack[top - 1];
                                 pc++;
                             }
                             case Bytecodes.LONG_NEG -> {
-                                var v = (LongValue) stack[--top];
-                                stack[top++] = new LongValue(-v.value);
+                                pstack[top - 1] = -pstack[top - 1];
                                 pc++;
                             }
                             case Bytecodes.DOUBLE_NEG -> {
-                                var v = (DoubleValue) stack[--top];
-                                stack[top++] = new DoubleValue(-v.value);
+                                pstack[top - 1] = Double.doubleToRawLongBits(-Double.longBitsToDouble(pstack[top - 1]));
                                 pc++;
                             }
                             case Bytecodes.FLOAT_NEG -> {
-                                var v = (FloatValue) stack[--top];
-                                stack[top++] = new FloatValue(-v.value);
+                                pstack[top - 1] = Float.floatToRawIntBits(-Float.intBitsToFloat((int) pstack[top - 1]));
                                 pc++;
                             }
                             case Bytecodes.LONG_TO_DOUBLE -> {
-                                var v = (LongValue) stack[--top];
-                                stack[top++] = new DoubleValue(v.value);
+                                pstack[top - 1] = Double.doubleToRawLongBits((double) pstack[top - 1]);
+                                ptag[top - 1] = TAG_DOUBLE;
                                 pc++;
                             }
                             case Bytecodes.DOUBLE_TO_LONG -> {
-                                var v = (DoubleValue) stack[--top];
-                                stack[top++] = new LongValue((long) v.value);
+                                pstack[top - 1] = (long) Double.longBitsToDouble(pstack[top - 1]);
+                                ptag[top - 1] = TAG_LONG;
                                 pc++;
                             }
                             case Bytecodes.INT_TO_LONG -> {
-                                var v = (IntValue) stack[--top];
-                                stack[top++] = new LongValue(v.value);
+                                pstack[top - 1] = (int) pstack[top - 1];
+                                ptag[top - 1] = TAG_LONG;
                                 pc++;
                             }
                             case Bytecodes.INT_TO_CHAR -> {
-                                var v = (IntValue) stack[--top];
-                                stack[top++] = new IntValue((char) v.value);
+                                pstack[top - 1] = (char) (int) pstack[top - 1];
                                 pc++;
                             }
                             case Bytecodes.INT_TO_SHORT -> {
-                                var v = (IntValue) stack[--top];
-                                stack[top++] = new IntValue((short) v.value);
+                                pstack[top - 1] = (short) (int) pstack[top - 1];
                                 pc++;
                             }
                             case Bytecodes.INT_TO_BYTE -> {
-                                var v = (IntValue) stack[--top];
-                                stack[top++] = new IntValue((byte) v.value);
+                                pstack[top - 1] = (byte) (int) pstack[top - 1];
                                 pc++;
                             }
                             case Bytecodes.LONG_TO_INT -> {
-                                var v = (LongValue) stack[--top];
-                                stack[top++] = new IntValue((int) v.value);
+                                pstack[top - 1] = (int) pstack[top - 1];
+                                ptag[top - 1] = TAG_INT;
                                 pc++;
                             }
                             case Bytecodes.INT_TO_DOUBLE -> {
-                                var v = (IntValue) stack[--top];
-                                stack[top++] = new DoubleValue(v.value);
+                                pstack[top - 1] = Double.doubleToRawLongBits((double) (int) pstack[top - 1]);
+                                ptag[top - 1] = TAG_DOUBLE;
                                 pc++;
                             }
                             case Bytecodes.DOUBLE_TO_INT -> {
-                                var v = (DoubleValue) stack[--top];
-                                stack[top++] = new IntValue((int) v.value);
+                                pstack[top - 1] = (int) Double.longBitsToDouble(pstack[top - 1]);
+                                ptag[top - 1] = TAG_INT;
                                 pc++;
                             }
                             case Bytecodes.INT_TO_FLOAT -> {
-                                var v = (IntValue) stack[--top];
-                                stack[top++] = new FloatValue((float) v.value);
+                                pstack[top - 1] = Float.floatToRawIntBits((float) (int) pstack[top - 1]);
+                                ptag[top - 1] = TAG_FLOAT;
                                 pc++;
                             }
                             case Bytecodes.LONG_TO_FLOAT -> {
-                                var v = (LongValue) stack[--top];
-                                stack[top++] = new FloatValue((float) v.value);
+                                pstack[top - 1] = Float.floatToRawIntBits((float) pstack[top - 1]);
+                                ptag[top - 1] = TAG_FLOAT;
                                 pc++;
                             }
                             case Bytecodes.DOUBLE_TO_FLOAT -> {
-                                var v = (DoubleValue) stack[--top];
-                                stack[top++] = new FloatValue((float) v.value);
+                                pstack[top - 1] = Float.floatToRawIntBits((float) Double.longBitsToDouble(pstack[top - 1]));
+                                ptag[top - 1] = TAG_FLOAT;
                                 pc++;
                             }
                             case Bytecodes.FLOAT_TO_INT -> {
-                                var v = (FloatValue) stack[--top];
-                                stack[top++] = new IntValue((int) v.value);
+                                pstack[top - 1] = (int) Float.intBitsToFloat((int) pstack[top - 1]);
+                                ptag[top - 1] = TAG_INT;
                                 pc++;
                             }
                             case Bytecodes.FLOAT_TO_LONG -> {
-                                var v = (FloatValue) stack[--top];
-                                stack[top++] = new LongValue((long) v.value);
+                                pstack[top - 1] = (long) Float.intBitsToFloat((int) pstack[top - 1]);
+                                ptag[top - 1] = TAG_LONG;
                                 pc++;
                             }
                             case Bytecodes.FLOAT_TO_DOUBLE -> {
-                                var v = (FloatValue) stack[--top];
-                                stack[top++] = new DoubleValue(v.value);
+                                pstack[top - 1] = Double.doubleToRawLongBits((double) Float.intBitsToFloat((int) pstack[top - 1]));
+                                ptag[top - 1] = TAG_DOUBLE;
                                 pc++;
                             }
                             case Bytecodes.EQ -> {
-                                var v = ((IntValue) stack[--top]).value;
-                                stack[top++] = v == 0 ? one : zero;
+                                pstack[top - 1] = (int) pstack[top - 1] == 0 ? 1 : 0;
                                 pc++;
                             }
                             case Bytecodes.NE -> {
-                                var v = ((IntValue) stack[--top]).value;
-                                stack[top++] = v != 0 ? one : zero;
+                                pstack[top - 1] = (int) pstack[top - 1] != 0 ? 1 : 0;
                                 pc++;
                             }
                             case Bytecodes.GE -> {
-                                var v = ((IntValue) stack[--top]).value;
-                                stack[top++] = v >= 0 ? one : zero;
+                                pstack[top - 1] = (int) pstack[top - 1] >= 0 ? 1 : 0;
                                 pc++;
                             }
                             case Bytecodes.GT -> {
-                                var v = ((IntValue) stack[--top]).value;
-                                stack[top++] = v > 0 ? one : zero;
+                                pstack[top - 1] = (int) pstack[top - 1] > 0 ? 1 : 0;
                                 pc++;
                             }
                             case Bytecodes.LT -> {
-                                var v = ((IntValue) stack[--top]).value;
-                                stack[top++] = v < 0 ? one : zero;
+                                pstack[top - 1] = (int) pstack[top - 1] < 0 ? 1 : 0;
                                 pc++;
                             }
                             case Bytecodes.LE -> {
-                                var v = ((IntValue) stack[--top]).value;
-                                stack[top++] = v <= 0 ? one : zero;
+                                pstack[top - 1] = (int) pstack[top - 1] <= 0 ? 1 : 0;
                                 pc++;
                             }
                             case Bytecodes.INT_COMPARE -> {
-                                var v2 = ((IntValue) stack[--top]).value;
-                                var v1 = ((IntValue) stack[--top]).value;
-                                var r = (v1 < v2) ? -1 : ((v1 == v2) ? 0 : 1);
-                                stack[top++] = new IntValue(r);
+                                var v2 = (int) pstack[--top];
+                                var v1 = (int) pstack[--top];
+                                pstack[top] = (v1 < v2) ? -1 : ((v1 == v2) ? 0 : 1); ptag[top++] = TAG_INT;
                                 pc++;
                             }
                             case Bytecodes.LONG_COMPARE -> {
-                                var v2 = ((LongValue) stack[--top]).value;
-                                var v1 = ((LongValue) stack[--top]).value;
-                                var r = (v1 < v2) ? -1 : ((v1 == v2) ? 0 : 1);
-                                stack[top++] = new IntValue(r);
+                                var v2 = pstack[--top];
+                                var v1 = pstack[--top];
+                                pstack[top] = (v1 < v2) ? -1 : ((v1 == v2) ? 0 : 1); ptag[top++] = TAG_INT;
                                 pc++;
                             }
                             case Bytecodes.DOUBLE_COMPARE -> {
-                                var v2 = ((DoubleValue) stack[--top]).value;
-                                var v1 = ((DoubleValue) stack[--top]).value;
-                                var r = (v1 < v2) ? -1 : ((v1 == v2) ? 0 : 1);
-                                stack[top++] = new IntValue(r);
+                                var v2 = Double.longBitsToDouble(pstack[--top]);
+                                var v1 = Double.longBitsToDouble(pstack[--top]);
+                                pstack[top] = (v1 < v2) ? -1 : ((v1 == v2) ? 0 : 1); ptag[top++] = TAG_INT;
                                 pc++;
                             }
                             case Bytecodes.FLOAT_COMPARE -> {
-                                var v2 = ((FloatValue) stack[--top]).value;
-                                var v1 = ((FloatValue) stack[--top]).value;
-                                var r = (v1 < v2) ? -1 : ((v1 == v2) ? 0 : 1);
-                                stack[top++] = new IntValue(r);
+                                var v2 = Float.intBitsToFloat((int) pstack[--top]);
+                                var v1 = Float.intBitsToFloat((int) pstack[--top]);
+                                pstack[top] = (v1 < v2) ? -1 : ((v1 == v2) ? 0 : 1); ptag[top++] = TAG_INT;
                                 pc++;
                             }
                             case Bytecodes.REF_COMPARE_EQ -> {
-                                var v2 = (Value) stack[--top];
-                                var v1 = (Value) stack[--top];
-                                stack[top++] = v1.equals(v2) ? one : zero;
+                                ensureBoxed(top - 1); ensureBoxed(top - 2);
+                                var v2 = stack[--top];
+                                var v1 = stack[--top];
+                                stack[top] = null; pstack[top] = v1.equals(v2) ? 1 : 0; ptag[top++] = TAG_INT;
                                 pc++;
                             }
                             case Bytecodes.REF_COMPARE_NE -> {
-                                var v2 = (Value) stack[--top];
-                                var v1 = (Value) stack[--top];
-                                stack[top++] = !v1.equals(v2) ? one : zero;
+                                ensureBoxed(top - 1); ensureBoxed(top - 2);
+                                var v2 = stack[--top];
+                                var v1 = stack[--top];
+                                stack[top] = null; pstack[top] = !v1.equals(v2) ? 1 : 0; ptag[top++] = TAG_INT;
                                 pc++;
                             }
                             case Bytecodes.GET_FIELD -> {
                                 var i = stack[--top].resolveMvObject();
                                 var p = (FieldRef) constants[(bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff];
-                                stack[top++] = i.fields[p.getRawField().offset].value.toStackValue();
+                                unboxTo(top, i.fields[p.getRawField().offset].value.toStackValue());
+                                top++;
                                 pc += 3;
                             }
                             case Bytecodes.GET_METHOD -> {
                                 var i = stack[--top].resolveObject();
                                 var methodRef = (MethodRef) constants[(bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff];
-                                stack[top++] = i.getFunction(methodRef);
+                                stack[top] = i.getFunction(methodRef); ptag[top++] = TAG_OBJ;
                                 pc += 3;
                             }
                             case Bytecodes.GET_STATIC_FIELD -> {
                                 var fieldRef = (FieldRef) constants[(bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff];
                                 var staticFieldTable = StaticFieldTable.getInstance(fieldRef.getDeclaringType(), ContextUtil.getEntityContext());
-                                stack[top++] = staticFieldTable.get(fieldRef.getRawField()).toStackValue();
+                                unboxTo(top, staticFieldTable.get(fieldRef.getRawField()).toStackValue());
+                                top++;
                                 pc += 3;
                             }
                             case Bytecodes.GET_STATIC_METHOD -> {
                                 var methodRef = (MethodRef) constants[(bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff];
-                                stack[top++] = new FlowValue(methodRef, null);
+                                stack[top] = new FlowValue(methodRef, null); ptag[top++] = TAG_OBJ;
                                 pc += 3;
                             }
                             case Bytecodes.INSTANCE_OF -> {
+                                ensureBoxed(top - 1);
                                 var v = stack[--top];
                                 var targetType = (Type) constants[(bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff];
-                                stack[top++] = targetType.isInstance(v) ? one : zero;
+                                stack[top] = null; pstack[top] = targetType.isInstance(v) ? 1 : 0; ptag[top++] = TAG_INT;
                                 pc += 3;
                             }
                             case Bytecodes.ARRAY_LENGTH -> {
                                 var a = stack[--top].resolveArray();
-                                stack[top++] = new IntValue(a.length());
+                                stack[top] = null; pstack[top] = a.length(); ptag[top++] = TAG_INT;
                                 pc++;
                             }
                             case Bytecodes.STORE -> {
                                 var index = (bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff;
-                                var v = stack[--top];
-                                stack[base + index] = v;
+                                --top;
+                                var dst = base + index;
+                                stack[dst] = stack[top]; pstack[dst] = pstack[top]; ptag[dst] = ptag[top];
                                 pc += 3;
                             }
                             case Bytecodes.LOAD -> {
                                 var index = (bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff;
-                                stack[top++] = stack[base + index];
+                                var src = base + index;
+                                stack[top] = stack[src]; pstack[top] = pstack[src]; ptag[top] = ptag[src];
+                                top++;
                                 pc += 3;
                             }
                             case Bytecodes.LOAD_CONTEXT_SLOT -> {
                                 var contextIndex = (bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff;
                                 var slotIndex = (bytes[pc + 3] & 0xff) << 8 | bytes[pc + 4] & 0xff;
-                                stack[top++] = Objects.requireNonNull(closureContext).get(contextIndex, slotIndex);
+                                unboxTo(top, Objects.requireNonNull(closureContext).get(contextIndex, slotIndex));
+                                top++;
                                 pc += 5;
                             }
                             case Bytecodes.STORE_CONTEXT_SLOT -> {
                                 var contextIndex = (bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff;
                                 var slotIndex = (bytes[pc + 3] & 0xff) << 8 | bytes[pc + 4] & 0xff;
+                                ensureBoxed(top - 1);
                                 Objects.requireNonNull(closureContext).set(contextIndex, slotIndex, stack[--top]);
                                 pc += 5;
                             }
                             case Bytecodes.LOAD_CONSTANT -> {
                                 var value = (Value) constants[(bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff];
-                                stack[top++] = value;
+                                unboxTo(top, value);
+                                top++;
                                 pc += 3;
                             }
                             case Bytecodes.NEW_ARRAY_WITH_DIMS -> {
@@ -1057,10 +1152,10 @@ public class VmStack {
                                 var dimensions = (bytes[pc + 3] & 0xff) << 8 | bytes[pc + 4] & 0xff;
                                 var dims = new int[dimensions];
                                 for (int i = dimensions - 1; i >= 0; i--) {
-                                    dims[i] = ((IntValue) stack[--top]).value;
+                                    dims[i] = (int) pstack[--top];
                                 }
                                 Instances.initArray(array, dims, 0);
-                                stack[top++] = array.getReference();
+                                stack[top] = array.getReference(); ptag[top++] = TAG_OBJ;
                                 pc += 5;
                             }
                             case Bytecodes.VOID_RETURN -> {
@@ -1070,6 +1165,7 @@ public class VmStack {
                                     callContext.instanceRepository().updateMemoryIndex(obj);
                                 }
                                 Arrays.fill(stack, base, base + code.getFrameSize(), null);
+                                Arrays.fill(ptag, base, base + code.getFrameSize(), TAG_OBJ);
                                 if (fp == 0)
                                     return FlowExecResult.of(null);
                                 var frame = frames[--fp];
@@ -1084,14 +1180,14 @@ public class VmStack {
                                 closureContext = frame.closureContext;
                             }
                             case Bytecodes.DUP -> {
-                                stack[top] = stack[top++ - 1];
+                                stack[top] = stack[top - 1]; pstack[top] = pstack[top - 1]; ptag[top] = ptag[top - 1];
+                                top++;
                                 pc++;
                             }
                             case Bytecodes.DUP2 -> {
-                                var v1 = stack[top - 2];
-                                var v2 = stack[top - 1];
-                                stack[top++] = v1;
-                                stack[top++] = v2;
+                                stack[top] = stack[top - 2]; pstack[top] = pstack[top - 2]; ptag[top] = ptag[top - 2];
+                                stack[top + 1] = stack[top - 1]; pstack[top + 1] = pstack[top - 1]; ptag[top + 1] = ptag[top - 1];
+                                top += 2;
                                 pc++;
                             }
                             case Bytecodes.POP -> {
@@ -1099,38 +1195,38 @@ public class VmStack {
                                 pc++;
                             }
                             case Bytecodes.DUP_X1 -> {
-                                var v = stack[top] = stack[top - 1];
-                                stack[top - 1] = stack[top - 2];
-                                stack[top - 2] = v;
+                                stack[top] = stack[top - 1]; pstack[top] = pstack[top - 1]; ptag[top] = ptag[top - 1];
+                                stack[top - 1] = stack[top - 2]; pstack[top - 1] = pstack[top - 2]; ptag[top - 1] = ptag[top - 2];
+                                stack[top - 2] = stack[top]; pstack[top - 2] = pstack[top]; ptag[top - 2] = ptag[top];
                                 top++;
                                 pc++;
                             }
                             case Bytecodes.DUP_X2 -> {
-                                var v = stack[top] = stack[top - 1];
-                                stack[top - 1] = stack[top - 2];
-                                stack[top - 2] = stack[top - 3];
-                                stack[top - 3] = v;
+                                stack[top] = stack[top - 1]; pstack[top] = pstack[top - 1]; ptag[top] = ptag[top - 1];
+                                stack[top - 1] = stack[top - 2]; pstack[top - 1] = pstack[top - 2]; ptag[top - 1] = ptag[top - 2];
+                                stack[top - 2] = stack[top - 3]; pstack[top - 2] = pstack[top - 3]; ptag[top - 2] = ptag[top - 3];
+                                stack[top - 3] = stack[top]; pstack[top - 3] = pstack[top]; ptag[top - 3] = ptag[top];
                                 top++;
                                 pc++;
                             }
                             case Bytecodes.LOAD_PARENT -> {
                                 var v = stack[--top];
                                 var idx = (bytes[pc + 1] & 0xff) << 8 | (bytes[pc + 2] & 0xff);
-                                stack[top++] = requireNonNull(v.resolveMvObject().getParent(idx)).getReference();
+                                stack[top] = requireNonNull(v.resolveMvObject().getParent(idx)).getReference(); ptag[top++] = TAG_OBJ;
                                 pc += 3;
                             }
                             case Bytecodes.LOAD_CHILDREN -> {
                                 var v = stack[--top];
-                                stack[top++] = Instances.arrayValue(Utils.map(v.resolveMvObject().getChildren(), Instance::getReference));
+                                stack[top] = Instances.arrayValue(Utils.map(v.resolveMvObject().getChildren(), Instance::getReference)); ptag[top++] = TAG_OBJ;
                                 pc++;
                             }
                             case Bytecodes.ID -> {
                                 var v = stack[--top];
-                                stack[top++] = Instances.stringInstance(v.resolveMvObject().getStringId());
+                                stack[top] = Instances.stringInstance(v.resolveMvObject().getStringId()); ptag[top++] = TAG_OBJ;
                                 pc++;
                             }
                             case Bytecodes.TABLE_SWITCH -> {
-                                var k = ((IntValue) stack[--top]).value;
+                                var k = (int) pstack[--top];
                                 int p = pc + 4 & 0xfffffffc;
                                 int defaultOffset = (bytes[p] & 0xff) << 24 | (bytes[p + 1] & 0xff) << 16
                                         | (bytes[p + 2] & 0xff) << 8 | bytes[p + 3] & 0xff;
@@ -1149,7 +1245,7 @@ public class VmStack {
                                 pc += offset;
                             }
                             case Bytecodes.LOOKUP_SWITCH -> {
-                                var k = ((IntValue) stack[--top]).value;
+                                var k = (int) pstack[--top];
                                 int p = pc + 4 & 0xfffffffc;
                                 int offset = (bytes[p] & 0xff) << 24 | (bytes[p + 1] & 0xff) << 16
                                         | (bytes[p + 2] & 0xff) << 8 | bytes[p + 3] & 0xff;
@@ -1180,6 +1276,7 @@ public class VmStack {
                             case Bytecodes.SET_FIELD_REFRESH -> {
                                 int fieldIndex = (bytes[pc + 1] & 0xff) << 8 | bytes[pc + 2] & 0xff;
                                 var field = (FieldRef) constants[fieldIndex];
+                                ensureBoxed(top - 1);
                                 var value = stack[--top];
                                 var instance = stack[--top].resolveMvObject();
                                 instance.fields[field.getRawField().offset].value = field.getPropertyType().fromStackValue(value);
@@ -1199,7 +1296,10 @@ public class VmStack {
                             pc = h.pc;
                         else {
                             var f = frames[h.fp];
-                            Arrays.fill(stack, f.base + f.callableRef.getCode().getFrameSize(), base + code.getFrameSize(), null);
+                            int cleanFrom = f.base + f.callableRef.getCode().getFrameSize();
+                            int cleanTo = base + code.getFrameSize();
+                            Arrays.fill(stack, cleanFrom, cleanTo, null);
+                            Arrays.fill(ptag, cleanFrom, cleanTo, TAG_OBJ);
                             fp = h.fp;
                             base = f.base;
                             top = f.top;
@@ -1210,10 +1310,11 @@ public class VmStack {
                             constants = callableRef.getTypeMetadata().getValues();
                             closureContext = f.closureContext;
                         }
-                        stack[top++] = exception.getReference();
+                        stack[top] = exception.getReference(); ptag[top++] = TAG_OBJ;
                     }
                     else {
                         Arrays.fill(stack, 0, base + code.getFrameSize(), null);
+                        Arrays.fill(ptag, 0, base + code.getFrameSize(), TAG_OBJ);
                         return FlowExecResult.ofException(exception);
                     }
 

--- a/test/src/test/java/org/manul/compiler/DualStackTest.java
+++ b/test/src/test/java/org/manul/compiler/DualStackTest.java
@@ -1,0 +1,269 @@
+package org.manul.compiler;
+
+import org.junit.Assert;
+import org.manul.util.ApiNamedObject;
+
+import java.util.List;
+
+public class DualStackTest extends ManulTestBase {
+
+    private static final String MNL = "manul/basics/dualstack/DualStackTest.mnl";
+
+    private Object call(String method, List<Object> args) {
+        return callMethod(ApiNamedObject.of("lab"), method, args);
+    }
+
+    // --- Group A: Integer arithmetic loops ---
+
+    public void testFibonacci() {
+        deploy(MNL);
+        assertEquals(0, call("fibonacci", List.of(0)));
+        assertEquals(1, call("fibonacci", List.of(1)));
+        assertEquals(55, call("fibonacci", List.of(10)));
+        assertEquals(6765, call("fibonacci", List.of(20)));
+    }
+
+    public void testSumOfSquares() {
+        deploy(MNL);
+        assertEquals(55, call("sumOfSquares", List.of(5)));
+        assertEquals(385, call("sumOfSquares", List.of(10)));
+    }
+
+    public void testGcd() {
+        deploy(MNL);
+        assertEquals(6, call("gcd", List.of(48, 18)));
+        assertEquals(25, call("gcd", List.of(100, 75)));
+        assertEquals(1, call("gcd", List.of(17, 13)));
+    }
+
+    // --- Group B: Long arithmetic ---
+
+    public void testLongFibonacci() {
+        deploy(MNL);
+        assertEquals(12586269025L, call("longFibonacci", List.of(50)));
+    }
+
+    public void testLongBitwiseOps() {
+        deploy(MNL);
+        // a=0xFF, b=0x0F: x=0xFF, y=0x0F, z=0xF0. (255+15)*240 = 64800
+        assertEquals(64800L, call("longBitwiseOps", List.of(0xFF, 0x0F)));
+    }
+
+    public void testLongShifts() {
+        deploy(MNL);
+        // (1<<10) + (1>>10) + (1>>>10) = 1024 + 0 + 0 = 1024
+        assertEquals(1024L, call("longShifts", List.of(1, 10)));
+        // (-1<<2) + (-1>>2) + (-1>>>2)
+        // -1L<<2 = -4, -1L>>2 = -1, -1L>>>2 = 4611686018427387903
+        // sum = -4 + -1 + 4611686018427387903 = 4611686018427387898
+        assertEquals(4611686018427387898L, call("longShifts", List.of(-1, 2)));
+    }
+
+    // --- Group C: Double arithmetic ---
+
+    public void testNewtonsSquareRoot() {
+        deploy(MNL);
+        var result = (double) call("newtonsSquareRoot", List.of(2.0, 10));
+        assertEquals(Math.sqrt(2.0), result, 1e-10);
+    }
+
+    public void testDotProduct() {
+        deploy(MNL);
+        assertEquals(11.0, call("dotProduct", List.of(1.0, 2.0, 3.0, 4.0)));
+    }
+
+    // --- Group D: Float arithmetic ---
+
+    public void testFloatAccumulate() {
+        deploy(MNL);
+        // sum of i*0.5 for i=1..10 = 0.5+1.0+1.5+2.0+2.5+3.0+3.5+4.0+4.5+5.0 = 27.5
+        assertEquals(27.5f, (float) call("floatAccumulate", List.of(10)), 0.01f);
+    }
+
+    // --- Group E: Type conversions ---
+
+    public void testIntToLongToDouble() {
+        deploy(MNL);
+        assertEquals(42.5, call("intToLongToDouble", List.of(42)));
+    }
+
+    public void testDoubleToFloatToInt() {
+        deploy(MNL);
+        assertEquals(3, call("doubleToFloatToInt", List.of(3.14)));
+    }
+
+    public void testRoundTrip() {
+        deploy(MNL);
+        assertEquals(42, call("roundTrip", List.of(42)));
+        assertEquals(0, call("roundTrip", List.of(0)));
+        assertEquals(-7, call("roundTrip", List.of(-7)));
+    }
+
+    // --- Group F: Comparisons ---
+
+    public void testIntCompareChain() {
+        deploy(MNL);
+        // 1<2, 2<3, 1<3 → 3
+        assertEquals(3, call("intCompareChain", List.of(1, 2, 3)));
+        // 3>2, 2>1, 3>1 → 0
+        assertEquals(0, call("intCompareChain", List.of(3, 2, 1)));
+        // 1<2, 2==2, 1<2 → 2
+        assertEquals(2, call("intCompareChain", List.of(1, 2, 2)));
+    }
+
+    public void testLongCompare() {
+        deploy(MNL);
+        assertEquals(-1, call("longCompare", List.of(1, 2)));
+        assertEquals(0, call("longCompare", List.of(2, 2)));
+        assertEquals(1, call("longCompare", List.of(3, 2)));
+    }
+
+    public void testDoubleCompare() {
+        deploy(MNL);
+        assertEquals(-1, call("doubleCompare", List.of(1.0, 2.0)));
+        assertEquals(0, call("doubleCompare", List.of(2.0, 2.0)));
+        assertEquals(1, call("doubleCompare", List.of(3.0, 2.0)));
+    }
+
+    public void testFloatCompare() {
+        deploy(MNL);
+        assertEquals(-1, call("floatCompare", List.of(1.0, 2.0)));
+        assertEquals(0, call("floatCompare", List.of(2.0, 2.0)));
+        assertEquals(1, call("floatCompare", List.of(3.0, 2.0)));
+    }
+
+    // --- Group G: Negate ---
+
+    public void testNegateInt() {
+        deploy(MNL);
+        assertEquals(-42, call("negateInt", List.of(42)));
+        assertEquals(0, call("negateInt", List.of(0)));
+    }
+
+    public void testNegateLong() {
+        deploy(MNL);
+        assertEquals(-100L, call("negateLong", List.of(100)));
+    }
+
+    public void testNegateDouble() {
+        deploy(MNL);
+        assertEquals(-3.14, (double) call("negateDouble", List.of(3.14)), 0.0);
+    }
+
+    public void testNegateFloat() {
+        deploy(MNL);
+        assertEquals(-1.5f, (float) call("negateFloat", List.of(1.5)), 0.0f);
+    }
+
+    // --- Group H: Boolean tests ---
+
+    public void testAllComparisons() {
+        deploy(MNL);
+        // a<b: ne(2) + lt(4) + le(8) = 14
+        assertEquals(14, call("allComparisons", List.of(3, 5)));
+        // a==b: eq(1) + le(8) + ge(32) = 41
+        assertEquals(41, call("allComparisons", List.of(5, 5)));
+        // a>b: ne(2) + gt(16) + ge(32) = 50
+        assertEquals(50, call("allComparisons", List.of(7, 5)));
+    }
+
+    // --- Group I: Closures ---
+
+    public void testClosureCapture() {
+        deploy(MNL);
+        // adder(5)=15, adder(20)=30 → 45
+        assertEquals(45, call("testClosureCapture", List.of()));
+    }
+
+    // --- Group J: Array operations ---
+
+    public void testArrayIntSum() {
+        deploy(MNL);
+        assertEquals(15, call("arrayIntSum", List.of(List.of(1, 2, 3, 4, 5))));
+        assertEquals(0, call("arrayIntSum", List.of(List.of(0, 0, 0))));
+    }
+
+    public void testBubbleSortAndSum() {
+        deploy(MNL);
+        // [5,3,1,4,2] → sorted [1,2,3,4,5] → 1*1+2*2+3*3+4*4+5*5 = 55
+        assertEquals(55, call("bubbleSortAndSum", List.of(List.of(5, 3, 1, 4, 2))));
+    }
+
+    // --- Group K: Nested calls ---
+
+    public void testNestedArithmetic() {
+        deploy(MNL);
+        // add(mul(2,3), square(4)) = 6 + 16 = 22
+        assertEquals(22, call("nestedArithmetic", List.of(2, 3, 4)));
+    }
+
+    public void testPower() {
+        deploy(MNL);
+        assertEquals(1, call("power", List.of(2, 0)));
+        assertEquals(1024, call("power", List.of(2, 10)));
+        assertEquals(59049, call("power", List.of(3, 10)));
+    }
+
+    // --- Group L: Exception handling ---
+
+    public void testDivideWithCatch() {
+        deploy(MNL);
+        assertEquals(3, call("divideWithCatch", List.of(10, 3)));
+        assertEquals(-1, call("divideWithCatch", List.of(10, 0)));
+    }
+
+    public void testLoopWithException() {
+        deploy(MNL);
+        // i=0: 100/(-5)=-20; i=1: 100/(-4)=-25; i=2: 100/(-3)=-33;
+        // i=3: 100/(-2)=-50; i=4: 100/(-1)=-100; i=5: exception→999;
+        // i=6: 100/1=100; i=7: 100/2=50; i=8: 100/3=33; i=9: 100/4=25
+        // total = -20-25-33-50-100+999+100+50+33+25 = 979
+        assertEquals(979, call("loopWithException", List.of(10)));
+    }
+
+    // --- Group M: DUP patterns ---
+
+    public void testDupPattern() {
+        deploy(MNL);
+        // arr=[1,2,3,4,5], n=10
+        // i=0: arr[0]=1+0=1, sum=1
+        // i=1: arr[1]=2+1=3, sum=4
+        // i=2: arr[2]=3+2=5, sum=9
+        // i=3: arr[3]=4+3=7, sum=16
+        // i=4: arr[4]=5+4=9, sum=25
+        // i=5: arr[0]=1+5=6, sum=31
+        // i=6: arr[1]=3+6=9, sum=40
+        // i=7: arr[2]=5+7=12, sum=52
+        // i=8: arr[3]=7+8=15, sum=67
+        // i=9: arr[4]=9+9=18, sum=85
+        assertEquals(85, call("testDupPattern", List.of(10)));
+    }
+
+    // --- Group N: Mixed primitive/object ---
+
+    public void testStringLengthSum() {
+        deploy(MNL);
+        assertEquals(11, call("stringLengthSum", List.of(List.of("hello", "world", "!"))));
+    }
+
+    public void testIntToString() {
+        deploy(MNL);
+        assertEquals("42", call("intToString", List.of(42)));
+        assertEquals("-7", call("intToString", List.of(-7)));
+    }
+
+    // --- Group O: Complex control flow ---
+
+    public void testCollatz() {
+        deploy(MNL);
+        assertEquals(0, call("collatz", List.of(1)));
+        assertEquals(111, call("collatz", List.of(27)));
+    }
+
+    public void testCountPrimes() {
+        deploy(MNL);
+        assertEquals(25, call("countPrimes", List.of(100)));
+        assertEquals(4, call("countPrimes", List.of(10)));
+    }
+
+}

--- a/test/src/test/resources/manul/basics/dualstack/DualStackTest.mnl
+++ b/test/src/test/resources/manul/basics/dualstack/DualStackTest.mnl
@@ -1,0 +1,289 @@
+package dualstack
+
+@Bean
+class Lab {
+
+    // --- Group A: Tight integer arithmetic loops ---
+
+    fn fibonacci(n: int) -> int {
+        if (n <= 1) return n
+        var a = 0
+        var b = 1
+        for (i in 2...(n + 1)) {
+            var tmp = a + b
+            a = b
+            b = tmp
+        }
+        return b
+    }
+
+    fn sumOfSquares(n: int) -> int {
+        var sum = 0
+        for (i in 1...(n + 1)) {
+            sum += i * i
+        }
+        return sum
+    }
+
+    fn gcd(a: int, b: int) -> int {
+        while (b != 0) {
+            var t = b
+            b = a % t
+            a = t
+        }
+        return a
+    }
+
+    // --- Group B: Long arithmetic ---
+
+    fn longFibonacci(n: int) -> long {
+        if (n <= 1) return n as long
+        var a: long = 0
+        var b: long = 1
+        for (i in 2...(n + 1)) {
+            var tmp = a + b
+            a = b
+            b = tmp
+        }
+        return b
+    }
+
+    fn longBitwiseOps(a: long, b: long) -> long {
+        var x = a | b
+        var y = a & b
+        var z = a ^ b
+        return (x + y) * z
+    }
+
+    fn longShifts(v: long, shift: int) -> long {
+        return (v << shift) + (v >> shift) + (v >>> shift)
+    }
+
+    // --- Group C: Double arithmetic ---
+
+    fn newtonsSquareRoot(n: double, iterations: int) -> double {
+        var guess = n / 2.0
+        for (i in 0...iterations) {
+            guess = (guess + n / guess) / 2.0
+        }
+        return guess
+    }
+
+    fn dotProduct(a1: double, b1: double, a2: double, b2: double) -> double {
+        return a1 * a2 + b1 * b2
+    }
+
+    // --- Group D: Float arithmetic ---
+
+    fn floatAccumulate(n: int) -> float {
+        var sum: float = 0.0f
+        for (i in 1...(n + 1)) {
+            sum += (i as float) * 0.5f
+        }
+        return sum
+    }
+
+    // --- Group E: Type conversions ---
+
+    fn intToLongToDouble(v: int) -> double {
+        var l: long = v as long
+        var d: double = l as double
+        return d + 0.5
+    }
+
+    fn doubleToFloatToInt(v: double) -> int {
+        var f: float = v as float
+        return f as int
+    }
+
+    fn roundTrip(v: int) -> int {
+        var l: long = v as long
+        var d: double = l as double
+        var f: float = d as float
+        var l2: long = f as long
+        return l2 as int
+    }
+
+    // --- Group F: Comparisons producing int results ---
+
+    fn intCompareChain(a: int, b: int, c: int) -> int {
+        var r1 = a < b ? 1 : 0
+        var r2 = b < c ? 1 : 0
+        var r3 = a < c ? 1 : 0
+        return r1 + r2 + r3
+    }
+
+    fn longCompare(a: long, b: long) -> int {
+        return a < b ? -1 : a == b ? 0 : 1
+    }
+
+    fn doubleCompare(a: double, b: double) -> int {
+        return a < b ? -1 : a == b ? 0 : 1
+    }
+
+    fn floatCompare(a: float, b: float) -> int {
+        return a < b ? -1 : a == b ? 0 : 1
+    }
+
+    // --- Group G: Negate operations ---
+
+    fn negateInt(v: int) -> int { return -v }
+    fn negateLong(v: long) -> long { return -v }
+    fn negateDouble(v: double) -> double { return -v }
+    fn negateFloat(v: float) -> float { return -v }
+
+    // --- Group H: Boolean tests from comparison results ---
+
+    fn allComparisons(a: int, b: int) -> int {
+        var score = 0
+        if (a == b) score += 1
+        if (a != b) score += 2
+        if (a < b) score += 4
+        if (a <= b) score += 8
+        if (a > b) score += 16
+        if (a >= b) score += 32
+        return score
+    }
+
+    // --- Group I: Closures capturing primitives ---
+
+    priv fn makeAdder(base: int) -> (int) -> int {
+        return x -> x + base
+    }
+
+    fn testClosureCapture() -> int {
+        var adder = makeAdder(10)
+        return adder(5) + adder(20)
+    }
+
+    // --- Group J: Array operations with primitive index/values ---
+
+    fn arrayIntSum(arr: int[]) -> int {
+        var sum = 0
+        for (i in 0...arr.length) {
+            sum += arr[i]
+        }
+        return sum
+    }
+
+    priv fn arraySwap(arr: int[], i: int, j: int) {
+        var tmp = arr[i]
+        arr[i] = arr[j]
+        arr[j] = tmp
+    }
+
+    fn bubbleSortAndSum(arr: int[]) -> int {
+        var n = arr.length
+        for (i in 0...n) {
+            for (j in 0...(n - i - 1)) {
+                if (arr[j] > arr[j + 1]) {
+                    arraySwap(arr, j, j + 1)
+                }
+            }
+        }
+        var sum = 0
+        for (i in 0...n) {
+            sum += arr[i] * (i + 1)
+        }
+        return sum
+    }
+
+    // --- Group K: Nested calls passing primitives through frames ---
+
+    priv fn add(a: int, b: int) -> int { return a + b }
+    priv fn mul(a: int, b: int) -> int { return a * b }
+    priv fn square(n: int) -> int { return mul(n, n) }
+
+    fn nestedArithmetic(a: int, b: int, c: int) -> int {
+        return add(mul(a, b), square(c))
+    }
+
+    fn power(base: int, exp: int) -> int {
+        if (exp == 0) return 1
+        if (exp == 1) return base
+        return base * power(base, exp - 1)
+    }
+
+    // --- Group L: Try/catch with primitives on stack ---
+
+    fn divideWithCatch(a: int, b: int) -> int {
+        try {
+            return a / b
+        } catch (e: Exception) {
+            return -1
+        }
+    }
+
+    fn loopWithException(n: int) -> int {
+        var sum = 0
+        for (i in 0...n) {
+            try {
+                sum += 100 / (i - 5)
+            } catch (e: Exception) {
+                sum += 999
+            }
+        }
+        return sum
+    }
+
+    // --- Group M: DUP patterns with primitives ---
+
+    fn testDupPattern(n: int) -> int {
+        var arr: int[] = new int[] {1, 2, 3, 4, 5}
+        var sum = 0
+        for (i in 0...n) {
+            arr[i % 5] = arr[i % 5] + i
+            sum += arr[i % 5]
+        }
+        return sum
+    }
+
+    // --- Group N: Mixed primitive/object operations ---
+
+    fn stringLengthSum(strings: string[]) -> int {
+        var total = 0
+        for (s in strings) {
+            total += s.length()
+        }
+        return total
+    }
+
+    fn intToString(v: int) -> string {
+        return "" + v
+    }
+
+    // --- Group O: Complex control flow with primitives ---
+
+    fn collatz(n: int) -> int {
+        var steps = 0
+        var v = n
+        while (v != 1) {
+            if (v % 2 == 0) {
+                v = v / 2
+            } else {
+                v = v * 3 + 1
+            }
+            steps++
+        }
+        return steps
+    }
+
+    priv fn isPrime(n: int) -> bool {
+        if (n < 2) return false
+        var d = 2
+        while (d * d <= n) {
+            if (n % d == 0) return false
+            d++
+        }
+        return true
+    }
+
+    fn countPrimes(limit: int) -> int {
+        var count = 0
+        for (n in 2...(limit + 1)) {
+            if (isPrime(n)) count++
+        }
+        return count
+    }
+
+}


### PR DESCRIPTION
## Summary
- Add parallel `long[] pstack` + `byte[] ptag` arrays to `VmStack` for unboxed primitive storage alongside the existing `Value[] stack`
- Eliminates boxing overhead (no more `new IntValue(...)` allocations) in arithmetic, comparisons, variable load/store, and control flow operations
- Primitives (int/long/float/double) stored as raw IEEE 754 bits; boxing only at boundaries (native method calls, field access, closure capture, type checks)

## Test plan
- [x] All 595 existing tests pass with zero regressions
- [x] New `DualStackTest` (33 tests) covers: integer loops, long/float/double arithmetic, type conversions, comparisons, negation, closures, arrays, nested calls, exception handling, DUP patterns, mixed primitive/object ops, complex control flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)